### PR TITLE
Refactor Size & Pos to use generics

### DIFF
--- a/examples/raymarching/main.rs
+++ b/examples/raymarching/main.rs
@@ -15,6 +15,7 @@ use gl::types::*;
 use cgmath::{Point3, Vector3};
 use cgmath::vec3;
 
+use noire::render::Size;
 use noire::render::shader::*;
 use noire::render::program::*;
 use noire::render::traits::*;

--- a/examples/raymarching/main.rs
+++ b/examples/raymarching/main.rs
@@ -131,19 +131,16 @@ fn main() {
         let size = window.get_framebuffer_size();
 
         program.bind();
-        program.uniform(
-            "u_resolution",
-            Uniform::Size(size.width as f32, size.height as f32),
-        );
+        program.uniform("u_resolution", size.into());
         program.uniform("u_aspect", camera.aspect.into());
-        program.uniform("u_time", Uniform::Float(elapsed));
-        program.uniform("u_znear", Uniform::Float(camera.znear));
-        program.uniform("u_zfar", Uniform::Float(camera.zfar));
-        program.uniform("u_cameraPos", Uniform::Point3(camera.position));
+        program.uniform("u_time", elapsed.into());
+        program.uniform("u_znear", camera.znear.into());
+        program.uniform("u_zfar", camera.zfar.into());
+        program.uniform("u_cameraPos", camera.position.into());
         program.uniform("u_camView", Uniform::Mat4(camera.invert_view().unwrap()));
-        program.uniform("u_ambientColor", Uniform::Color(color!(0.0, 0.0, 0.0)));
-        program.uniform("u_light", Uniform::Float3(0.0, 20.0, 0.0));
-        program.uniform("u_lightColor", Uniform::Color(color!(0.4, 1.0, 1.0)));
+        program.uniform("u_ambientColor", color!(0.0, 0.0, 0.0).into());
+        program.uniform("u_light", vec3(0.0, 20.0, 0.0).into());
+        program.uniform("u_lightColor", color!(0.4, 1.0, 1.0).into());
 
         vao.bind();
         vao.draw();

--- a/examples/triangles/main.rs
+++ b/examples/triangles/main.rs
@@ -71,7 +71,7 @@ fn main() {
 
         program.bind();
         // is there a way to use deref coercion to not specify Uniform type?
-        program.uniform("u_resolution", Uniform::Float2(size.width as f32, size.height as f32));
+        program.uniform("u_resolution", size.into());
         program.uniform("u_time", elapsed.into());
 
         vao.bind();

--- a/examples/triangles/main.rs
+++ b/examples/triangles/main.rs
@@ -72,7 +72,7 @@ fn main() {
         program.bind();
         // is there a way to use deref coercion to not specify Uniform type?
         program.uniform("u_resolution", Uniform::Float2(size.width as f32, size.height as f32));
-        program.uniform("u_time", Uniform::Float(elapsed as f32));
+        program.uniform("u_time", elapsed.into());
 
         vao.bind();
         vao.draw();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,3 +5,12 @@ pub mod shader;
 pub mod vertex;
 pub mod vertex_buffer;
 pub mod window;
+
+/// Struct to provide size dimensions
+#[derive(Debug, Copy, Clone)]
+pub struct Size<T> {
+    /// width
+    pub width: T,
+    /// height
+    pub height: T,
+}

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::ptr;
 use std::str;
 
+use super::Size;
 use render::shader::Shader;
 use render::traits::Bindable;
 use render::shader::create_shdaer_from_file;
@@ -49,11 +50,35 @@ impl From<f32> for Uniform {
     }
 }
 
-// impl From<Size<u32>> for Uniform {
-//     fn from(s: Size) -> Self {
-//         Uniform::Size(s.width as f32, s.height as f32)
-//     }
-// }
+impl From<Size<u32>> for Uniform {
+    fn from(s: Size<u32>) -> Self {
+        Uniform::Size(s.width as f32, s.height as f32)
+    }
+}
+
+impl From<Size<f32>> for Uniform {
+    fn from(s: Size<f32>) -> Self {
+        Uniform::Size(s.width, s.height)
+    }
+}
+
+impl From<Point3<f32>> for Uniform {
+    fn from(p: Point3<f32>) -> Self {
+        Uniform::Point3(p)
+    }
+}
+
+impl From<Color> for Uniform {
+    fn from(c: Color) -> Self {
+        Uniform::Color(c)
+    }
+}
+
+impl From<Vector3<f32>> for Uniform {
+    fn from(v: Vector3<f32>) -> Self {
+        Uniform::Vec3(v)
+    }
+}
 
 fn get_link_error(program: u32) -> String {
     let log_text: String;

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -49,6 +49,12 @@ impl From<f32> for Uniform {
     }
 }
 
+// impl From<Size<u32>> for Uniform {
+//     fn from(s: Size) -> Self {
+//         Uniform::Size(s.width as f32, s.height as f32)
+//     }
+// }
+
 fn get_link_error(program: u32) -> String {
     let log_text: String;
     unsafe {

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -15,11 +15,11 @@ use input::keyboard::Key;
 
 /// Struct to provide size dimensions
 #[derive(Debug, Copy, Clone)]
-pub struct Size {
-    /// width in pixels
-    pub width: u32,
-    /// height in pixels
-    pub height: u32,
+pub struct Size<T> {
+    /// width
+    pub width: T,
+    /// height
+    pub height: T,
 }
 
 /// Struct to provide coordinates
@@ -35,7 +35,7 @@ pub enum Fullscreen {
     /// Use current screen resolution
     Current,
     /// Specify dimensions directly
-    Size(Size),
+    Size(Size<u32>),
 }
 
 /// Trait that handles a Window
@@ -43,7 +43,7 @@ pub enum Fullscreen {
 /// The basic behavior of a Window is defined here
 pub trait Window {
     /// Returns the size of the window
-    fn size(&self) -> Size;
+    fn size(&self) -> Size<u32>;
     /// Returns the position of the window
     fn pos(&self) -> Pos;
     /// Closes the window
@@ -67,9 +67,9 @@ pub trait OpenGLWindow: Window {
     /// Set the Window into fullscreen mode
     fn set_fullscreen(&mut self, mode: Fullscreen);
     /// set windowed mode
-    fn set_windowed(&mut self, pos: &Pos, size: &Size);
+    fn set_windowed(&mut self, pos: &Pos, size: &Size<u32>);
     /// Return the size of the frame buffer
-    fn get_framebuffer_size(&self) -> Size;
+    fn get_framebuffer_size(&self) -> Size<u32>;
     /// Clear window to a color
     fn clear(&self, r: f32, g: f32, b: f32, a: f32);
     /// Clear the depth buffer to a value
@@ -103,7 +103,7 @@ pub fn set_fullscreen(glfw: &mut Glfw, window: &mut glfw::Window, mode: Fullscre
         let monitor = m.unwrap();
         let video_mode: glfw::VidMode = monitor.get_video_mode().unwrap();
 
-        let mut new_size = Size {
+        let mut new_size: Size<u32> = Size {
             width: 0,
             height: 0,
         };
@@ -230,7 +230,7 @@ impl Window for RenderWindow {
         Pos { x, y }
     }
 
-    fn size(&self) -> Size {
+    fn size(&self) -> Size<u32> {
         let (width, height) = self.window.get_size();
         Size {
             width: width as u32,
@@ -278,7 +278,7 @@ impl OpenGLWindow for RenderWindow {
         set_fullscreen(&mut self.glfw, &mut self.window, mode);
     }
     /// Set the Window into Windowed mode
-    fn set_windowed(&mut self, pos: &Pos, size: &Size) {
+    fn set_windowed(&mut self, pos: &Pos, size: &Size<u32>) {
         self.glfw.set_swap_interval(glfw::SwapInterval::Sync(1));
         self.window.set_monitor(
             glfw::WindowMode::Windowed,
@@ -290,7 +290,7 @@ impl OpenGLWindow for RenderWindow {
         );
     }
     /// Return the size of the frame buffer
-    fn get_framebuffer_size(&self) -> Size {
+    fn get_framebuffer_size(&self) -> Size<u32> {
         let (width, height) = self.window.get_framebuffer_size();
         Size {
             width: width as u32,

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -15,11 +15,11 @@ use input::keyboard::Key;
 use super::Size;
 
 /// Struct to provide coordinates
-pub struct Pos {
+pub struct Pos<T> {
     /// x coordinate
-    pub x: i32,
+    pub x: T,
     /// y coordinate
-    pub y: i32,
+    pub y: T,
 }
 
 /// Struct to define fullscreen mode
@@ -37,7 +37,7 @@ pub trait Window {
     /// Returns the size of the window
     fn size(&self) -> Size<u32>;
     /// Returns the position of the window
-    fn pos(&self) -> Pos;
+    fn pos(&self) -> Pos<i32>;
     /// Closes the window
     fn close(&mut self);
     /// Display the window
@@ -59,7 +59,7 @@ pub trait OpenGLWindow: Window {
     /// Set the Window into fullscreen mode
     fn set_fullscreen(&mut self, mode: Fullscreen);
     /// set windowed mode
-    fn set_windowed(&mut self, pos: &Pos, size: &Size<u32>);
+    fn set_windowed(&mut self, pos: &Pos<i32>, size: &Size<u32>);
     /// Return the size of the frame buffer
     fn get_framebuffer_size(&self) -> Size<u32>;
     /// Clear window to a color
@@ -217,7 +217,7 @@ impl RenderWindow {
 
 /// Implement Window functions
 impl Window for RenderWindow {
-    fn pos(&self) -> Pos {
+    fn pos(&self) -> Pos<i32> {
         let (x, y) = self.window.get_pos();
         Pos { x, y }
     }
@@ -270,7 +270,7 @@ impl OpenGLWindow for RenderWindow {
         set_fullscreen(&mut self.glfw, &mut self.window, mode);
     }
     /// Set the Window into Windowed mode
-    fn set_windowed(&mut self, pos: &Pos, size: &Size<u32>) {
+    fn set_windowed(&mut self, pos: &Pos<i32>, size: &Size<u32>) {
         self.glfw.set_swap_interval(glfw::SwapInterval::Sync(1));
         self.window.set_monitor(
             glfw::WindowMode::Windowed,

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -12,15 +12,7 @@ use glfw::{Context, Glfw, Error, WindowEvent};
 
 use input::{Button, Input};
 use input::keyboard::Key;
-
-/// Struct to provide size dimensions
-#[derive(Debug, Copy, Clone)]
-pub struct Size<T> {
-    /// width
-    pub width: T,
-    /// height
-    pub height: T,
-}
+use super::Size;
 
 /// Struct to provide coordinates
 pub struct Pos {


### PR DESCRIPTION
This PR refactors the `Size` struct to use generics.

* extract `Size` struct to parent folder, refactor to use generic type
* refactor passing of parameters to `Programm.uniform` function using `From` conversion methods
