### PR TITLE
Feature: Add index buffer struct

### DIFF
--- a/examples/triangles/main.rs
+++ b/examples/triangles/main.rs
@@ -13,6 +13,7 @@ use noire::render::program::*;
 use noire::render::traits::*;
 use noire::render::vertex::*;
 use noire::render::vertex_buffer::*;
+use noire::render::index_buffer::*;
 use noire::render::window::{OpenGLWindow,RenderWindow,Window};
 
 use notify::*;
@@ -22,6 +23,7 @@ use std::thread;
 use std::thread::JoinHandle;
 
 static VERTICES: [GLfloat; 8] = [-1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0];
+static INDICES: [GLuint; 6] = [0, 1, 2, 2, 3, 1];
 
 fn main() {
     let mut window = RenderWindow::create(600, 600, "Hello This is window")
@@ -42,8 +44,11 @@ fn main() {
 
     // create vertex data
     let vb = VertexBuffer::create(&VERTICES, 2, gl::TRIANGLE_STRIP);
+    let ib = IndexBuffer::create(&INDICES);
+
     let mut vao = VertexArrayObject::new();
     vao.add_vb(vb);
+    vao.add_ib(ib);
 
     let start_time = Instant::now();
 

--- a/src/render/index_buffer.rs
+++ b/src/render/index_buffer.rs
@@ -19,14 +19,14 @@ impl IndexBuffer {
         unsafe {
             gl::GenBuffers(1, &mut id);
 
-            gl::BindBuffer(gl::ARRAY_BUFFER, id);
+            gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, id);
             gl::BufferData(
-                gl::ARRAY_BUFFER,
+                gl::ELEMENT_ARRAY_BUFFER,
                 total_size as GLsizeiptr,
                 mem::transmute(&indices[0]),
                 gl::STATIC_DRAW,
             );
-            gl::BindBuffer(gl::ARRAY_BUFFER, 0);
+            gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, 0);
         }
 
         IndexBuffer {
@@ -39,13 +39,13 @@ impl IndexBuffer {
 impl Bindable for IndexBuffer {
     fn bind(&self) {
         unsafe {
-            gl::BindBuffer(gl::ARRAY_BUFFER, self.id);
+            gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, self.id);
         }
     }
 
     fn unbind(&self) {
         unsafe {
-            gl::BindBuffer(gl::ARRAY_BUFFER, 0);
+            gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, 0);
         }
     }
 }

--- a/src/render/index_buffer.rs
+++ b/src/render/index_buffer.rs
@@ -1,0 +1,59 @@
+use std::mem;
+
+use gl;
+use gl::types::*;
+
+use render::traits::{Bindable};
+
+pub struct IndexBuffer {
+    pub id: u32,
+    pub count: usize,
+}
+
+impl IndexBuffer {
+    pub fn create(indices: &[u32]) -> IndexBuffer {
+        let total_size = indices.len() * mem::size_of::<u32>();
+
+        let mut id = 0;
+
+        unsafe {
+            gl::GenBuffers(1, &mut id);
+
+            gl::BindBuffer(gl::ARRAY_BUFFER, id);
+            gl::BufferData(
+                gl::ARRAY_BUFFER,
+                total_size as GLsizeiptr,
+                mem::transmute(&indices[0]),
+                gl::STATIC_DRAW,
+            );
+            gl::BindBuffer(gl::ARRAY_BUFFER, 0);
+        }
+
+        IndexBuffer {
+            id,
+            count: indices.len(),
+        }
+    }
+}
+
+impl Bindable for IndexBuffer {
+    fn bind(&self) {
+        unsafe {
+            gl::BindBuffer(gl::ARRAY_BUFFER, self.id);
+        }
+    }
+
+    fn unbind(&self) {
+        unsafe {
+            gl::BindBuffer(gl::ARRAY_BUFFER, 0);
+        }
+    }
+}
+
+impl Drop for IndexBuffer {
+    fn drop(&mut self) {
+        unsafe {
+            gl::DeleteBuffers(1, &self.id);
+        }
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,5 +1,6 @@
 pub mod traits;
 
+pub mod index_buffer;
 pub mod program;
 pub mod shader;
 pub mod vertex;

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -3,11 +3,13 @@ use std::ptr;
 use gl;
 
 use render::traits::{Bindable, Drawable};
-use render::vertex_buffer::VertexBuffer;
+use render::index_buffer::{IndexBuffer};
+use render::vertex_buffer::{VertexBuffer};
 
 pub struct VertexArrayObject {
     id: u32,
     vbs: Vec<VertexBuffer>,
+    ibs: Vec<IndexBuffer>,
 }
 
 impl VertexArrayObject {
@@ -19,11 +21,16 @@ impl VertexArrayObject {
         VertexArrayObject {
             id: id,
             vbs: vec![],
+            ibs: vec![],
         }
     }
 
     pub fn add_vb(&mut self, vb: VertexBuffer) {
         self.vbs.push(vb);
+    }
+
+    pub fn add_ib(&mut self, ib: IndexBuffer) {
+        self.ibs.push(ib);
     }
 }
 
@@ -42,6 +49,10 @@ impl Bindable for VertexArrayObject {
             }
             stride += vb.component_size();
         }
+
+        for ref ib in self.ibs.iter() {
+            ib.bind();
+        }
     }
 
     fn unbind(&self) {
@@ -58,11 +69,20 @@ impl Bindable for VertexArrayObject {
 }
 
 impl Drawable for VertexArrayObject {
+    /// Render the VertexArrayObject
     fn draw(&self) {
         let count: i32 = self.vbs[0].count as i32;
-        let render_type = self.vbs[0].render_type;
-        unsafe {
-            gl::DrawArrays(render_type, 0, count);
+
+        // render buffers depending on index buffers are set or not
+        if self.ibs.len() == 0 {
+            let render_type = self.vbs[0].render_type;
+            unsafe {
+                gl::DrawArrays(render_type, 0, count);
+            }
+        } else {
+            unsafe {
+                gl::DrawElements(gl::TRIANGLES, 6, gl::UNSIGNED_INT, ptr::null());
+            }
         }
     }
 }


### PR DESCRIPTION
Add an `IndexBuffer` struct to render VAO with indices, e.g. triangle strip, to improve re-use of vertex data.