### PR TITLE
Add example with spinning cube

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ keywords = ["noire", "gl", "3d", "graphics"]
 repository = "https://github.com/justahero/noire-rs.git"
 
 [[example]]
+name = "spinningcube"
+path = "examples/01-spinning-cube/main.rs"
+
+[[example]]
 name = "triangles"
 path = "examples/triangles/main.rs"
 

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -12,6 +12,7 @@ use gl::types::*;
 use cgmath::*;
 
 use noire::math::*;
+use noire::math::color::Color;
 use noire::math::camera::*;
 use noire::mesh;
 use noire::mesh::mesh::Mesh;
@@ -51,6 +52,7 @@ fn main() {
             point3(0.0, 0.0, 0.0),
             vec3(0.0, 1.0, 0.0)
         );
+    let light_pos = vec3(3.0, 2.0, 0.0);
 
     loop {
         let now = Instant::now();
@@ -73,6 +75,7 @@ fn main() {
         program.uniform("u_modelView", model_view.into());
         program.uniform("u_modelViewProjection", model_view_proj.into());
         program.uniform("u_normalMatrix", normal_matrix.into());
+        program.uniform("u_light_pos", light_pos.into());
 
         vao.bind();
         vao.draw();

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -1,0 +1,95 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
+extern crate gl;
+extern crate noire;
+extern crate notify;
+
+use gl::types::*;
+
+use noire::render::shader::*;
+use noire::render::program::*;
+use noire::render::traits::*;
+use noire::render::vertex::*;
+use noire::render::vertex_buffer::*;
+use noire::render::index_buffer::*;
+use noire::render::window::{OpenGLWindow,RenderWindow,Window};
+
+use notify::*;
+use std::sync::mpsc::channel;
+use std::time::{Duration, Instant};
+use std::thread;
+use std::thread::JoinHandle;
+
+static VERTICES: [GLfloat; 8] = [-1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0];
+static INDICES: [GLuint; 6] = [0, 1, 2, 2, 3, 1];
+
+fn main() {
+    let mut window = RenderWindow::create(600, 600, "Hello This is window")
+        .expect("Failed to create Render Window");
+
+    // create shader program
+    let vertex_file = String::from("./examples/triangles/shaders/vertex.glsl");
+    let fragment_file = String::from("./examples/triangles/shaders/fragment.glsl");
+    let mut program: Program = Program::compile_from_files(&vertex_file, &fragment_file).unwrap();
+
+    // enable file watching
+    let files = vec![&vertex_file, &fragment_file];
+    let (tx, rx) = channel();
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(125)).unwrap();
+    for file in &files {
+        watcher.watch(&file, RecursiveMode::NonRecursive).unwrap();
+    }
+
+    // create vertex data
+    let vb = VertexBuffer::create(&VERTICES, 2, gl::TRIANGLE_STRIP);
+    let ib = IndexBuffer::create(&INDICES);
+
+    let mut vao = VertexArrayObject::new();
+    vao.add_vb(vb);
+    vao.add_ib(ib);
+
+    let start_time = Instant::now();
+
+    loop {
+        // check if there is a file system event
+        match rx.try_recv() {
+            Ok(DebouncedEvent::Write(path)) => {
+                match Program::compile_from_files(&vertex_file, &fragment_file) {
+                    Ok(new_program) => {
+                        program = new_program;
+                    }
+                    Err(e) => println!("Failed to set new program: {:?}", e),
+                }
+            }
+            _ => (),
+        }
+
+        let now = Instant::now();
+        let elapsed = now.duration_since(start_time);
+        let elapsed = (elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 * 1e-9) as f32;
+
+        window.clear(0.3, 0.3, 0.3, 1.0);
+
+        let size = window.get_framebuffer_size();
+
+        program.bind();
+        // is there a way to use deref coercion to not specify Uniform type?
+        program.uniform("u_resolution", size.into());
+        program.uniform("u_time", elapsed.into());
+
+        vao.bind();
+        vao.draw();
+        vao.unbind();
+
+        program.unbind();
+
+        window.swap_buffers();
+
+        window.poll_events();
+        if window.should_close() {
+            return;
+        }
+    }
+}

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -21,6 +21,7 @@ use noire::render::shader::*;
 use noire::render::program::*;
 use noire::render::traits::*;
 use noire::render::vertex::*;
+use noire::render::{Capability};
 use noire::render::window::{OpenGLWindow,RenderWindow,Window};
 
 use notify::*;
@@ -32,6 +33,8 @@ use std::thread::JoinHandle;
 fn main() {
     let mut window = RenderWindow::create(600, 600, "Hello This is window")
         .expect("Failed to create Render Window");
+
+    window.enable(Capability::DepthTest);
 
     // create shader program
     let vertex_file = String::from("./examples/01-spinning-cube/shaders/vertex.glsl");

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -64,7 +64,7 @@ fn main() {
         let anim = Matrix4::from_angle_y(Rad::from(Deg(elapsed * 45.0)));
         let model_view = camera.view * anim;
         let model_view_proj = camera.projection * model_view;
-        let normal_matrix = model_view.invert().unwrap().transpose();
+        let normal_matrix: Matrix3<f32> = convert_to_matrix3(&model_view).invert().unwrap().transpose();
 
         program.bind();
 

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -60,11 +60,14 @@ fn main() {
         let elapsed = (elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 * 1e-9) as f32;
 
         window.clear(0.95, 0.95, 0.95, 1.0);
+        window.clear_depth(1.0);
 
         let size = window.get_framebuffer_size();
 
-        let anim = Matrix4::from_angle_y(Rad::from(Deg(elapsed * 45.0)));
-        let model_view = camera.view * anim;
+        let rotate_x = Matrix4::from_angle_x(Rad::from(Deg(elapsed * 22.5)));
+        let rotate_y = Matrix4::from_angle_y(Rad::from(Deg(elapsed * 45.0)));
+
+        let model_view = camera.view * rotate_y * rotate_x;
         let model_view_proj = camera.projection * model_view;
         let normal_matrix: Matrix3<f32> = convert_to_matrix3(&model_view).invert().unwrap().transpose();
 

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -55,7 +55,7 @@ fn main() {
             point3(0.0, 0.0, 0.0),
             vec3(0.0, 1.0, 0.0)
         );
-    let light_pos = vec3(3.0, 2.0, 0.0);
+    let light_pos = vec3(-4.0, 0.0, 2.0);
 
     loop {
         let now = Instant::now();
@@ -76,12 +76,13 @@ fn main() {
 
         program.bind();
 
+        program.uniform("u_cameraPos", camera.position.into());
         program.uniform("u_resolution", size.into());
         program.uniform("u_time", elapsed.into());
         program.uniform("u_modelView", model_view.into());
         program.uniform("u_modelViewProjection", model_view_proj.into());
         program.uniform("u_normalMatrix", normal_matrix.into());
-        program.uniform("u_light_pos", light_pos.into());
+        program.uniform("u_lightPos", light_pos.into());
 
         vao.bind();
         vao.draw();

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -65,17 +65,8 @@ fn main() {
 
         let size = window.get_framebuffer_size();
 
-        // update matrices
-        let view = Matrix4::look_at(
-            Point3::new(0.0, 1.0, -4.0),
-            Point3::new(0.0, 0.0, 0.0),
-            vec3(0.0, 1.0, 0.0),
-        );
-        // let projection = perspective(Deg(45.0), 1.0 * (size.width as f32) / (size.height as f32), 0.1, 10.0);
-
         let anim = Matrix4::from_angle_y(Rad::from(Deg(elapsed * 45.0)));
-
-        let model_view = view * anim;
+        let model_view = camera.view * anim;
         let model_view_proj = camera.projection * model_view;
 
         program.bind();

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -2,11 +2,14 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 
+extern crate cgmath;
 extern crate gl;
 extern crate noire;
 extern crate notify;
 
 use gl::types::*;
+
+use cgmath::{Matrix4, SquareMatrix};
 
 use noire::mesh;
 use noire::mesh::mesh::Mesh;
@@ -40,8 +43,9 @@ fn main() {
 
     let start_time = Instant::now();
 
-    loop {
+    let model_view_proj = Matrix4::<f32>::identity();
 
+    loop {
         let now = Instant::now();
         let elapsed = now.duration_since(start_time);
         let elapsed = (elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 * 1e-9) as f32;
@@ -54,6 +58,7 @@ fn main() {
         // is there a way to use deref coercion to not specify Uniform type?
         program.uniform("u_resolution", size.into());
         program.uniform("u_time", elapsed.into());
+        program.uniform("u_modelViewProjection", model_view_proj.into());
 
         vao.bind();
         vao.draw();

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -10,7 +10,8 @@ extern crate notify;
 use gl::types::*;
 
 use cgmath::vec3;
-use cgmath::{Deg, Point3, Matrix4, SquareMatrix, Vector3};
+use cgmath::{Deg, Matrix4, Point3, Rad, SquareMatrix, Vector3};
+use cgmath::{perspective};
 
 use noire::math::*;
 use noire::math::camera::*;
@@ -50,7 +51,7 @@ fn main() {
     camera
         .perspective(60.0, window.aspect(), 0.1, 80.0)
         .lookat(
-            point3(0.0, 0.0, -2.5),
+            point3(0.0, 1.0, -4.0),
             point3(0.0, 0.0, 0.0),
             vec3(0.0, 1.0, 0.0)
         );
@@ -65,15 +66,22 @@ fn main() {
         let size = window.get_framebuffer_size();
 
         // update matrices
-        let model_matrix    = Matrix4::from_angle_y(Deg(elapsed));
-        let model_view      = camera.view * model_matrix;
+        let view = Matrix4::look_at(
+            Point3::new(0.0, 1.0, -4.0),
+            Point3::new(0.0, 0.0, 0.0),
+            vec3(0.0, 1.0, 0.0),
+        );
+        // let projection = perspective(Deg(45.0), 1.0 * (size.width as f32) / (size.height as f32), 0.1, 10.0);
+
+        let anim = Matrix4::from_angle_y(Rad::from(Deg(elapsed * 45.0)));
+
+        let model_view = view * anim;
         let model_view_proj = camera.projection * model_view;
 
         program.bind();
 
         program.uniform("u_resolution", size.into());
         program.uniform("u_time", elapsed.into());
-        program.uniform("u_modelView", model_view.into());
         program.uniform("u_modelViewProjection", model_view_proj.into());
 
         vao.bind();

--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -9,9 +9,7 @@ extern crate notify;
 
 use gl::types::*;
 
-use cgmath::vec3;
-use cgmath::{Deg, Matrix4, Point3, Rad, SquareMatrix, Vector3};
-use cgmath::{perspective};
+use cgmath::*;
 
 use noire::math::*;
 use noire::math::camera::*;
@@ -22,8 +20,6 @@ use noire::render::shader::*;
 use noire::render::program::*;
 use noire::render::traits::*;
 use noire::render::vertex::*;
-use noire::render::vertex_buffer::*;
-use noire::render::index_buffer::*;
 use noire::render::window::{OpenGLWindow,RenderWindow,Window};
 
 use notify::*;
@@ -51,7 +47,7 @@ fn main() {
     camera
         .perspective(60.0, window.aspect(), 0.1, 80.0)
         .lookat(
-            point3(0.0, 1.0, -4.0),
+            point3(0.0, 1.0, -2.5),
             point3(0.0, 0.0, 0.0),
             vec3(0.0, 1.0, 0.0)
         );
@@ -68,12 +64,15 @@ fn main() {
         let anim = Matrix4::from_angle_y(Rad::from(Deg(elapsed * 45.0)));
         let model_view = camera.view * anim;
         let model_view_proj = camera.projection * model_view;
+        let normal_matrix = model_view.invert().unwrap().transpose();
 
         program.bind();
 
         program.uniform("u_resolution", size.into());
         program.uniform("u_time", elapsed.into());
+        program.uniform("u_modelView", model_view.into());
         program.uniform("u_modelViewProjection", model_view_proj.into());
+        program.uniform("u_normalMatrix", normal_matrix.into());
 
         vao.bind();
         vao.draw();

--- a/examples/01-spinning-cube/shaders/fragment.glsl
+++ b/examples/01-spinning-cube/shaders/fragment.glsl
@@ -2,9 +2,14 @@
 
 uniform vec2 u_resolution;
 uniform float u_time;
+uniform vec3 u_lightPos = vec3(0.0, 10.0, 2.0);
+
+in vec3 vertex;
 
 out vec4 out_color;
 
 void main() {
-    out_color = vec4(0.5, 0.5, 0.5, 1.0);
+    vec3 lightDir = normalize(u_lightPos - vertex);
+
+    out_color = vec4(lightDir, 1.0);
 }

--- a/examples/01-spinning-cube/shaders/fragment.glsl
+++ b/examples/01-spinning-cube/shaders/fragment.glsl
@@ -17,5 +17,5 @@ void main() {
 
     float intensity = max(dot(normal, lightDir), 0.0);
 
-    out_color = u_ambientColor * (1.0 - intensity);
+    out_color = intensity * u_lightColor;
 }

--- a/examples/01-spinning-cube/shaders/fragment.glsl
+++ b/examples/01-spinning-cube/shaders/fragment.glsl
@@ -1,0 +1,10 @@
+#version 330
+
+uniform vec2 u_resolution;
+uniform float u_time;
+
+out vec4 out_color;
+
+void main() {
+    out_color = vec4(0.5, 0.5, 0.5, 1.0);
+}

--- a/examples/01-spinning-cube/shaders/fragment.glsl
+++ b/examples/01-spinning-cube/shaders/fragment.glsl
@@ -1,8 +1,12 @@
 #version 330
 
+uniform vec3 u_cameraPos;
 uniform vec3 u_lightPos     = vec3(0.0, 6.0, -4.0);
 uniform vec4 u_lightColor   = vec4(1.0, 1.0, 1.0, 1.0);
 uniform vec4 u_ambientColor = vec4(0.1, 0.1, 0.1, 1.0);
+uniform vec4 u_diffuseColor = vec4(0.3, 0.5, 0.4, 1.0);
+uniform vec4 u_objectColor  = vec4(1.0, 1.0, 1.0, 1.0);
+uniform float u_shininess = 10.0;
 
 uniform vec2 u_resolution;
 uniform float u_time;
@@ -14,8 +18,19 @@ out vec4 out_color;
 
 void main() {
     vec3 lightDir = normalize(u_lightPos - vertex);
+    vec3 viewDir = normalize(u_cameraPos - vertex);
 
-    float intensity = max(dot(normal, lightDir), 0.0);
+    // ambient
+    vec4 ambientColor = u_ambientColor * u_objectColor;
 
-    out_color = intensity * u_lightColor;
+    // diffuse
+    float intensity = clamp(dot(normal, lightDir), 0.0, 1.0);
+    vec4 diffuseColor = u_objectColor * intensity;
+
+    // specular
+    vec3 reflectDir = reflect(-lightDir, normal);
+    float specular = pow(max(dot(viewDir, reflectDir), 0.0), u_shininess);
+    vec4 specularColor = u_lightColor * specular;
+
+    out_color = ambientColor + diffuseColor + specularColor;
 }

--- a/examples/01-spinning-cube/shaders/fragment.glsl
+++ b/examples/01-spinning-cube/shaders/fragment.glsl
@@ -2,14 +2,9 @@
 
 uniform vec2 u_resolution;
 uniform float u_time;
-uniform vec3 u_lightPos = vec3(0.0, 10.0, 2.0);
-
-in vec3 vertex;
 
 out vec4 out_color;
 
 void main() {
-    vec3 lightDir = normalize(u_lightPos - vertex);
-
-    out_color = vec4(lightDir, 1.0);
+    out_color = vec4(0.5, 0.5, 0.5, 1.0);
 }

--- a/examples/01-spinning-cube/shaders/fragment.glsl
+++ b/examples/01-spinning-cube/shaders/fragment.glsl
@@ -1,10 +1,21 @@
 #version 330
 
+uniform vec3 u_lightPos     = vec3(0.0, 6.0, -4.0);
+uniform vec4 u_lightColor   = vec4(1.0, 1.0, 1.0, 1.0);
+uniform vec4 u_ambientColor = vec4(0.1, 0.1, 0.1, 1.0);
+
 uniform vec2 u_resolution;
 uniform float u_time;
+
+in vec3 vertex;
+in vec3 normal;
 
 out vec4 out_color;
 
 void main() {
-    out_color = vec4(0.5, 0.5, 0.5, 1.0);
+    vec3 lightDir = normalize(u_lightPos - vertex);
+
+    float intensity = max(dot(normal, lightDir), 0.0);
+
+    out_color = u_ambientColor * (1.0 - intensity);
 }

--- a/examples/01-spinning-cube/shaders/vertex.glsl
+++ b/examples/01-spinning-cube/shaders/vertex.glsl
@@ -1,0 +1,7 @@
+#version 330
+
+in vec3 position;
+
+void main() {
+    gl_Position = vec4(position, 1.0);
+}

--- a/examples/01-spinning-cube/shaders/vertex.glsl
+++ b/examples/01-spinning-cube/shaders/vertex.glsl
@@ -1,9 +1,19 @@
 #version 330
 
 uniform mat4 u_modelViewProjection;
+uniform mat4 u_modelView;
+uniform mat3 u_normalMatrix;
 
-layout(location = 0) in vec3 position;
+layout(location = 0) in vec3 i_position;
+layout(location = 1) in vec3 i_normal;
+
+out vec3 vertex;
+out vec3 normal;
 
 void main() {
-    gl_Position = u_modelViewProjection * vec4(position, 1.0);
+    gl_Position = u_modelViewProjection * vec4(i_position, 1.0);
+
+    vertex = vec3(u_modelView * vec4(i_position, 1.0));
+
+    normal = normalize(u_normalMatrix * i_normal);
 }

--- a/examples/01-spinning-cube/shaders/vertex.glsl
+++ b/examples/01-spinning-cube/shaders/vertex.glsl
@@ -1,14 +1,9 @@
 #version 330
 
 uniform mat4 u_modelViewProjection;
-uniform mat4 u_modelView;
 
 layout(location = 0) in vec3 position;
 
-out vec3 vertex;
-
 void main() {
     gl_Position = u_modelViewProjection * vec4(position, 1.0);
-
-    vertex = vec3(u_modelView * vec4(position, 1.0));
 }

--- a/examples/01-spinning-cube/shaders/vertex.glsl
+++ b/examples/01-spinning-cube/shaders/vertex.glsl
@@ -1,7 +1,11 @@
 #version 330
 
+uniform mat4 u_modelViewProjection;
+
 in vec3 position;
 
+out vec3 vertex;
+
 void main() {
-    gl_Position = vec4(position, 1.0);
+    gl_Position = u_modelViewProjection * vec4(position, 1.0);
 }

--- a/examples/01-spinning-cube/shaders/vertex.glsl
+++ b/examples/01-spinning-cube/shaders/vertex.glsl
@@ -1,11 +1,14 @@
 #version 330
 
 uniform mat4 u_modelViewProjection;
+uniform mat4 u_modelView;
 
-in vec3 position;
+layout(location = 0) in vec3 position;
 
 out vec3 vertex;
 
 void main() {
     gl_Position = u_modelViewProjection * vec4(position, 1.0);
+
+    vertex = vec3(u_modelView * vec4(position, 1.0));
 }

--- a/examples/raymarching/main.rs
+++ b/examples/raymarching/main.rs
@@ -15,7 +15,7 @@ use gl::types::*;
 use cgmath::{Point3, Vector3};
 use cgmath::vec3;
 
-use noire::render::Size;
+use noire::render::{Primitive, Size};
 use noire::render::shader::*;
 use noire::render::program::*;
 use noire::render::traits::*;
@@ -90,7 +90,7 @@ fn main() {
         .set_position(point3(0.0, 2.0, 20.0));
 
     // create vertex data
-    let vb = VertexBuffer::create(&VERTICES, 2, gl::TRIANGLE_STRIP);
+    let vb = VertexBuffer::create(&VERTICES, 2, Primitive::TriangleStrip);
     let mut vao = VertexArrayObject::new();
     vao.add_vb(vb);
 

--- a/examples/triangles/main.rs
+++ b/examples/triangles/main.rs
@@ -8,6 +8,7 @@ extern crate notify;
 
 use gl::types::*;
 
+use noire::render::Primitive;
 use noire::render::shader::*;
 use noire::render::program::*;
 use noire::render::traits::*;
@@ -43,7 +44,7 @@ fn main() {
     }
 
     // create vertex data
-    let vb = VertexBuffer::create(&VERTICES, 2, gl::TRIANGLE_STRIP);
+    let vb = VertexBuffer::create(&VERTICES, 2, Primitive::TriangleStrip);
     let ib = IndexBuffer::create(&INDICES);
 
     let mut vao = VertexArrayObject::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ extern crate regex;
 
 pub mod input;
 pub mod math;
+pub mod mesh;
 pub mod render;

--- a/src/math/camera.rs
+++ b/src/math/camera.rs
@@ -32,7 +32,7 @@ impl Camera {
         }
     }
 
-    pub fn perspective(&mut self, fov: f32, aspect: f32, znear: f32, zfar: f32) -> &mut Camera {
+    pub fn perspective(&mut self, fov: f32, aspect: f32, znear: f32, zfar: f32) -> &mut Self {
         self.fov = fov;
         self.aspect = aspect;
         self.znear = znear;
@@ -97,7 +97,7 @@ impl Camera {
     fn update_view(&mut self) -> &mut Self {
         let rotation = Matrix4::from(self.orientation);
         let translation = Matrix4::from_translation(self.position.to_vec());
-        self.view = rotation * translation;
+        self.view = rotation * translation.invert().unwrap();
         self
     }
 }

--- a/src/math/camera.rs
+++ b/src/math/camera.rs
@@ -47,6 +47,7 @@ impl Camera {
         self
     }
 
+    // TODO change up vector to a default constant
     pub fn lookat(&mut self, eye: Point3<f32>, center: Point3<f32>, up: Vector3<f32>) -> &mut Self {
         self.position = eye.clone();
         self.view = Matrix4::look_at(eye, center, up);

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -2,7 +2,7 @@
 pub mod camera;
 pub mod color;
 
-use cgmath::Point3;
+use cgmath::{Matrix3, Matrix4, Point3, Quaternion};
 
 #[macro_export]
 macro_rules! color {
@@ -20,8 +20,6 @@ macro_rules! color {
 pub fn point3(x: f32, y: f32, z: f32) -> Point3<f32> {
     Point3 { x, y, z }
 }
-
-use cgmath::{Matrix4, Quaternion};
 
 pub fn convert_to_quaternion(mat: &Matrix4<f32>) -> Quaternion<f32> {
     let trace = mat.x.x + mat.y.y + mat.z.z;
@@ -59,4 +57,12 @@ pub fn convert_to_quaternion(mat: &Matrix4<f32>) -> Quaternion<f32> {
     }
 
     Quaternion::new(w, x, y, z)
+}
+
+pub fn convert_to_matrix3(mat: &Matrix4<f32>) -> Matrix3<f32> {
+    Matrix3::new(
+        mat.x.x, mat.x.y, mat.x.z,
+        mat.y.x, mat.y.y, mat.y.z,
+        mat.z.x, mat.z.y, mat.z.z,
+    )
 }

--- a/src/mesh/cube.rs
+++ b/src/mesh/cube.rs
@@ -1,6 +1,6 @@
 pub struct Cube {
     pub vertices: Vec<f32>,
-    // pub texcoords: Vec<f32>,
+    pub texcoords: Vec<f32>,
     // pub normals: Vec<f32>,
     pub indices: Vec<u32>,
 }
@@ -41,6 +41,40 @@ fn create_vertices(size: f32) -> Vec<f32> {
     ]
 }
 
+fn create_texcoords() -> Vec<f32> {
+    vec![
+      0.0,  0.0,
+      1.0,  0.0,
+      1.0,  1.0,
+      0.0,  1.0,
+
+      0.0,  0.0,
+      1.0,  0.0,
+      1.0,  1.0,
+      0.0,  1.0,
+
+      0.0,  0.0,
+      1.0,  0.0,
+      1.0,  1.0,
+      0.0,  1.0,
+
+      0.0,  0.0,
+      1.0,  0.0,
+      1.0,  1.0,
+      0.0,  1.0,
+
+      0.0,  0.0,
+      1.0,  0.0,
+      1.0,  1.0,
+      0.0,  1.0,
+
+      0.0,  0.0,
+      1.0,  0.0,
+      1.0,  1.0,
+      0.0,  1.0,
+    ]
+}
+
 fn create_indices() -> Vec<u32> {
     vec![
        0,  1,  2,    0,  2,  3,  // Front face
@@ -56,6 +90,7 @@ impl Cube {
     pub fn create(size: f32) -> Self {
         Cube {
             vertices: create_vertices(size),
+            texcoords: create_texcoords(),
             indices: create_indices(),
         }
     }

--- a/src/mesh/cube.rs
+++ b/src/mesh/cube.rs
@@ -1,0 +1,3 @@
+pub struct Cube {
+    
+}

--- a/src/mesh/cube.rs
+++ b/src/mesh/cube.rs
@@ -1,3 +1,64 @@
+use super::*;
+
 pub struct Cube {
-    
+    pub vertices: Vec<f32>,
+    // pub texcoords: Vec<f32>,
+    // pub normals: Vec<f32>,
+    pub indices: Vec<u32>,
+}
+
+fn create_vertices(size: f32) -> Vec<f32> {
+    let half = size / 2.0;
+
+    vec![
+      -half, -half,  half,
+       half, -half,  half,
+       half,  half,  half,
+      -half,  half,  half,
+
+      -half, -half, -half,
+      -half,  half, -half,
+       half,  half, -half,
+       half, -half, -half,
+
+      -half,  half, -half,
+      -half,  half,  half,
+       half,  half,  half,
+       half,  half, -half,
+
+      -half, -half, -half,
+       half, -half, -half,
+       half, -half,  half,
+      -half, -half,  half,
+
+       half, -half, -half,
+       half,  half, -half,
+       half,  half,  half,
+       half, -half,  half,
+
+      -half, -half, -half,
+      -half, -half,  half,
+      -half,  half,  half,
+      -half,  half, -half,
+    ]
+}
+
+fn create_indices() -> Vec<u32> {
+    vec![
+       0,  1,  2,    0,  2,  3,  // Front face
+       4,  5,  6,    4,  6,  7,  // Back face
+       8,  9, 10,    8, 10, 11,  // Top face
+      12, 13, 14,   12, 14, 15,  // Bottom face
+      16, 17, 18,   16, 18, 19,  // Right face
+      20, 21, 22,   20, 22, 23   // Left face
+    ]
+}
+
+impl Cube {
+    pub fn create(size: f32) -> Self {
+        Cube {
+            vertices: create_vertices(size),
+            indices: create_indices(),
+        }
+    }
 }

--- a/src/mesh/cube.rs
+++ b/src/mesh/cube.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 pub struct Cube {
     pub vertices: Vec<f32>,
     // pub texcoords: Vec<f32>,
@@ -60,5 +58,9 @@ impl Cube {
             vertices: create_vertices(size),
             indices: create_indices(),
         }
+    }
+
+    pub fn num_vertices(&self) -> usize {
+        self.vertices.len()
     }
 }

--- a/src/mesh/cube.rs
+++ b/src/mesh/cube.rs
@@ -1,7 +1,7 @@
 pub struct Cube {
     pub vertices: Vec<f32>,
     pub texcoords: Vec<f32>,
-    // pub normals: Vec<f32>,
+    pub normals: Vec<f32>,
     pub indices: Vec<u32>,
 }
 
@@ -75,6 +75,40 @@ fn create_texcoords() -> Vec<f32> {
     ]
 }
 
+fn create_normals() -> Vec<f32> {
+    vec![
+       0.0,  0.0,  1.0,
+       0.0,  0.0,  1.0,
+       0.0,  0.0,  1.0,
+       0.0,  0.0,  1.0,
+
+       0.0,  0.0, -1.0,
+       0.0,  0.0, -1.0,
+       0.0,  0.0, -1.0,
+       0.0,  0.0, -1.0,
+
+       0.0,  1.0,  0.0,
+       0.0,  1.0,  0.0,
+       0.0,  1.0,  0.0,
+       0.0,  1.0,  0.0,
+
+       0.0, -1.0,  0.0,
+       0.0, -1.0,  0.0,
+       0.0, -1.0,  0.0,
+       0.0, -1.0,  0.0,
+
+       1.0,  0.0,  0.0,
+       1.0,  0.0,  0.0,
+       1.0,  0.0,  0.0,
+       1.0,  0.0,  0.0,
+
+      -1.0,  0.0,  0.0,
+      -1.0,  0.0,  0.0,
+      -1.0,  0.0,  0.0,
+      -1.0,  0.0,  0.0,
+    ]
+}
+
 fn create_indices() -> Vec<u32> {
     vec![
        0,  1,  2,    0,  2,  3,  // Front face
@@ -91,12 +125,9 @@ impl Cube {
         Cube {
             vertices: create_vertices(size),
             texcoords: create_texcoords(),
+            normals: create_normals(),
             indices: create_indices(),
         }
-    }
-
-    pub fn num_components(&self) -> usize {
-        3
     }
 
     pub fn num_vertices(&self) -> usize {

--- a/src/mesh/cube.rs
+++ b/src/mesh/cube.rs
@@ -95,6 +95,10 @@ impl Cube {
         }
     }
 
+    pub fn num_components(&self) -> usize {
+        3
+    }
+
     pub fn num_vertices(&self) -> usize {
         self.vertices.len()
     }

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -14,8 +14,9 @@ impl Mesh {
     pub fn create(cube: Cube) -> Mesh {
         let mut vao = VertexArrayObject::new();
 
-        vao.add_vb(VertexBuffer::create(&cube.vertices, cube.num_components() as u32, Primitive::Triangles));
-        // vao.add_vb(VertexBuffer::create(&cube.texcoords, cube.num_vertices() as u32, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&cube.vertices, 3, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&cube.normals, 3, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&cube.texcoords, 2, Primitive::Triangles));
         vao.add_ib(IndexBuffer::create(&cube.indices));
 
         Mesh { vao }

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -1,10 +1,19 @@
+use super::cube::Cube;
+use render::vertex::VertexArrayObject;
+use render::vertex_buffer::VertexBuffer;
+use render::index_buffer::IndexBuffer;
+
 pub struct Mesh {
+    pub vao: VertexArrayObject,
+    // TODO add a few more properties, local object matrix
 }
 
 impl Mesh {
-    pub fn create() -> Result<Mesh, String> {
-        Ok(Mesh {
-            
-        })
+    pub fn create(cube: Cube) -> Mesh {
+        let mut vao = VertexArrayObject::new();
+        vao.add_vb(VertexBuffer::create(&cube.vertices, 2, gl::TRIANGLE_STRIP));
+        vao.add_ib(IndexBuffer::create(&cube.indices));
+
+        Mesh { vao }
     }
 }

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -15,8 +15,8 @@ impl Mesh {
         let mut vao = VertexArrayObject::new();
 
         vao.add_vb(VertexBuffer::create(&cube.vertices, cube.num_vertices() as u32, Primitive::Triangles));
-        vao.add_vb(VertexBuffer::create(&cube.texcoords, cube.num_vertices() as u32, Primitive::Triangles));
-        vao.add_ib(IndexBuffer::create(&cube.indices));
+        // vao.add_vb(VertexBuffer::create(&cube.texcoords, cube.num_vertices() as u32, Primitive::Triangles));
+        // vao.add_ib(IndexBuffer::create(&cube.indices));
 
         Mesh { vao }
     }

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -1,0 +1,10 @@
+pub struct Mesh {
+}
+
+impl Mesh {
+    pub fn create() -> Result<Mesh, String> {
+        Ok(Mesh {
+            
+        })
+    }
+}

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -14,9 +14,9 @@ impl Mesh {
     pub fn create(cube: Cube) -> Mesh {
         let mut vao = VertexArrayObject::new();
 
-        vao.add_vb(VertexBuffer::create(&cube.vertices, cube.num_vertices() as u32, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&cube.vertices, cube.num_components() as u32, Primitive::Triangles));
         // vao.add_vb(VertexBuffer::create(&cube.texcoords, cube.num_vertices() as u32, Primitive::Triangles));
-        // vao.add_ib(IndexBuffer::create(&cube.indices));
+        vao.add_ib(IndexBuffer::create(&cube.indices));
 
         Mesh { vao }
     }

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -1,4 +1,6 @@
 use super::cube::Cube;
+
+use render::Primitive;
 use render::vertex::VertexArrayObject;
 use render::vertex_buffer::VertexBuffer;
 use render::index_buffer::IndexBuffer;
@@ -11,7 +13,8 @@ pub struct Mesh {
 impl Mesh {
     pub fn create(cube: Cube) -> Mesh {
         let mut vao = VertexArrayObject::new();
-        vao.add_vb(VertexBuffer::create(&cube.vertices, 2, gl::TRIANGLE_STRIP));
+
+        vao.add_vb(VertexBuffer::create(&cube.vertices, cube.num_vertices() as u32, Primitive::Triangles));
         vao.add_ib(IndexBuffer::create(&cube.indices));
 
         Mesh { vao }

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -15,6 +15,7 @@ impl Mesh {
         let mut vao = VertexArrayObject::new();
 
         vao.add_vb(VertexBuffer::create(&cube.vertices, cube.num_vertices() as u32, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&cube.texcoords, cube.num_vertices() as u32, Primitive::Triangles));
         vao.add_ib(IndexBuffer::create(&cube.indices));
 
         Mesh { vao }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -1,5 +1,3 @@
 pub mod cube;
 pub mod mesh;
 
-pub trait Primitive {
-}

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -1,0 +1,5 @@
+pub mod cube;
+pub mod mesh;
+
+pub trait Primitive {
+}

--- a/src/render/index_buffer.rs
+++ b/src/render/index_buffer.rs
@@ -34,6 +34,10 @@ impl IndexBuffer {
             count: indices.len(),
         }
     }
+
+    pub fn size(&self) -> usize {
+        self.count
+    }
 }
 
 impl Bindable for IndexBuffer {

--- a/src/render/index_buffer.rs
+++ b/src/render/index_buffer.rs
@@ -35,7 +35,7 @@ impl IndexBuffer {
         }
     }
 
-    pub fn size(&self) -> usize {
+    pub fn num_indices(&self) -> usize {
         self.count
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,6 +3,7 @@ pub mod traits;
 pub mod index_buffer;
 pub mod program;
 pub mod shader;
+pub mod texture;
 pub mod vertex;
 pub mod vertex_buffer;
 pub mod window;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -16,3 +16,17 @@ pub struct Size<T> {
     /// height
     pub height: T,
 }
+
+pub enum Primitive {
+    Triangles,
+    TriangleStrip,
+}
+
+impl Primitive {
+    fn gl_primitive(&self) -> u32 {
+        match *self {
+            Primitive::Triangles     => gl::TRIANGLES,
+            Primitive::TriangleStrip => gl::TRIANGLE_STRIP,
+        }
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -18,7 +18,9 @@ pub struct Size<T> {
 }
 
 pub enum Primitive {
+    /// used to render separate triangles
     Triangles,
+    /// used to render connected triangle strips
     TriangleStrip,
 }
 
@@ -27,6 +29,21 @@ impl Primitive {
         match *self {
             Primitive::Triangles     => gl::TRIANGLES,
             Primitive::TriangleStrip => gl::TRIANGLE_STRIP,
+        }
+    }
+}
+
+/// An enum containing all capabilities that can be enabled / disabled (GL specific)
+pub enum Capability {
+    /// enable or disable depth tests
+    DepthTest,
+}
+
+/// Implements GL specific functions
+impl Capability {
+    fn gl_func(&self) -> u32 {
+        match *self {
+            Capability::DepthTest => gl::DEPTH_TEST
         }
     }
 }

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -1,4 +1,4 @@
-use cgmath::{Matrix, Matrix4, Point3, Vector2, Vector3};
+use cgmath::{Matrix, Matrix3, Matrix4, Point3, Vector2, Vector3};
 
 use math::color::Color;
 
@@ -35,6 +35,7 @@ pub enum Uniform {
     Float(f32),
     Float2(f32, f32),
     Float3(f32, f32, f32),
+    Mat3(Matrix3<f32>),
     Mat4(Matrix4<f32>),
     Vec2(Vector2<f32>),
     Vec3(Vector3<f32>),
@@ -75,6 +76,12 @@ impl From<Color> for Uniform {
 impl From<Vector3<f32>> for Uniform {
     fn from(v: Vector3<f32>) -> Self {
         Uniform::Vec3(v)
+    }
+}
+
+impl From<Matrix3<f32>> for Uniform {
+    fn from(m: Matrix3<f32>) -> Self {
+        Uniform::Mat3(m)
     }
 }
 
@@ -271,6 +278,7 @@ impl Program {
                 Uniform::Float(v) => Program::uniform1f(location, v),
                 Uniform::Float2(x, y) => Program::uniform2f(location, x, y),
                 Uniform::Float3(x, y, z) => Program::uniform3f(location, x, y, z),
+                Uniform::Mat3(m) => Program::matrix3(location, &m),
                 Uniform::Mat4(m) => Program::matrix4(location, &m),
                 Uniform::Vec2(v) => Program::uniform2f(location, v.x, v.y),
                 Uniform::Vec3(v) => Program::uniform3f(location, v.x, v.y, v.z),
@@ -283,6 +291,12 @@ impl Program {
     pub fn color(location: i32, color: Color) {
         unsafe {
             gl::Uniform4f(location, color.red, color.green, color.blue, color.alpha);
+        }
+    }
+
+    pub fn matrix3(location: i32, matrix: &Matrix3<f32>) {
+        unsafe {
+            gl::UniformMatrix3fv(location, 1, gl::FALSE, matrix.as_ptr());
         }
     }
 

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -78,6 +78,12 @@ impl From<Vector3<f32>> for Uniform {
     }
 }
 
+impl From<Matrix4<f32>> for Uniform {
+    fn from(m: Matrix4<f32>) -> Self {
+        Uniform::Mat4(m)
+    }
+}
+
 fn get_link_error(program: u32) -> String {
     let log_text: String;
     unsafe {

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,0 +1,11 @@
+pub struct Texture {
+
+}
+
+impl Texture {
+    pub fn create() -> Result<Self, String> {
+        Ok(Texture {
+            
+        })
+    }
+}

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,8 +1,4 @@
-// use std::mem;
-use std::ptr;
-
 use gl;
-use gl::types::*;
 
 use render::traits::{Bindable};
 
@@ -25,7 +21,19 @@ impl Texture {
         })
     }
 
-    pub fn linear(&mut self) -> &Self {
+    pub fn linear(&self) -> &Self {
+        unsafe {
+            gl::TexParameteri(self.id, gl::TEXTURE_MAG_FILTER, gl::LINEAR as i32);
+            gl::TexParameteri(self.id, gl::TEXTURE_MIN_FILTER, gl::LINEAR as i32);
+        }
+        self
+    }
+
+    pub fn clamp_to_edge(&self) -> &Self {
+        unsafe {
+            gl::TexParameteri(self.id, gl::TEXTURE_WRAP_S, gl::CLAMP_TO_EDGE as i32);
+            gl::TexParameteri(self.id, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as i32);
+        }
         self
     }
 }

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,11 +1,55 @@
-pub struct Texture {
+// use std::mem;
+use std::ptr;
 
+use gl;
+use gl::types::*;
+
+use render::traits::{Bindable};
+
+/// A texture struct
+pub struct Texture {
+    pub id: u32,
 }
 
 impl Texture {
     pub fn create() -> Result<Self, String> {
+        let mut id = 0;
+
+        unsafe {
+            gl::GenTextures(1, &mut id);
+            gl::BindTexture(gl::TEXTURE_2D, id);
+        }
+
         Ok(Texture {
-            
+            id
         })
+    }
+
+    pub fn linear(&mut self) -> &Self {
+        self
+    }
+}
+
+impl Bindable for Texture {
+    fn bind(&self) {
+        unsafe {
+            gl::ActiveTexture(gl::TEXTURE0);
+            gl::BindTexture(gl::TEXTURE_2D, self.id);
+        }
+    }
+
+    fn unbind(&self) {
+        unsafe {
+            gl::ActiveTexture(gl::TEXTURE0);
+            gl::BindTexture(gl::TEXTURE_2D, 0);
+        }
+    }
+}
+
+impl Drop for Texture {
+    fn drop(&mut self) {
+        unsafe {
+            gl::DeleteTextures(1, &self.id);
+        }
     }
 }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -46,7 +46,7 @@ impl Bindable for VertexArrayObject {
         for (i, ref vb) in self.vbs.iter().enumerate() {
             vb.bind();
             unsafe {
-                gl::VertexAttribPointer(i as u32, 2, gl::FLOAT, gl::FALSE, stride, ptr::null());
+                gl::VertexAttribPointer(i as u32, vb.num_components(), gl::FLOAT, gl::FALSE, stride, ptr::null());
                 gl::EnableVertexAttribArray(i as u32);
             }
             stride += vb.component_size();
@@ -81,7 +81,7 @@ impl Drawable for VertexArrayObject {
         } else {
             let ib = &self.ibs[0];
             unsafe {
-                gl::DrawElements(vb.render_type.gl_primitive(), ib.size() as i32, gl::UNSIGNED_INT, ptr::null());
+                gl::DrawElements(gl::TRIANGLES, ib.num_indices() as i32, gl::UNSIGNED_INT, ptr::null());
             }
         }
     }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -71,16 +71,16 @@ impl Bindable for VertexArrayObject {
 impl Drawable for VertexArrayObject {
     /// Render the VertexArrayObject
     fn draw(&self) {
-        let count: i32 = self.vbs[0].count as i32;
-
         // render buffers depending on index buffers are set or not
         if self.ibs.len() == 0 {
+            let vb = &self.vbs[0];
             unsafe {
-                gl::DrawArrays(self.vbs[0].gl_primitive(), 0, count);
+                gl::DrawArrays(gl::TRIANGLES, 0, vb.size() as i32);
             }
         } else {
+            let ib = &self.ibs[0];
             unsafe {
-                gl::DrawElements(gl::TRIANGLES, 6, gl::UNSIGNED_INT, ptr::null());
+                gl::DrawElements(gl::TRIANGLES, ib.size() as i32, gl::UNSIGNED_INT, ptr::null());
             }
         }
     }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -6,7 +6,9 @@ use render::traits::{Bindable, Drawable};
 use render::index_buffer::{IndexBuffer};
 use render::vertex_buffer::{VertexBuffer};
 
+/// A struct to represent a OpenGL vertex array object (VAO)
 pub struct VertexArrayObject {
+    /// the OpenGL instance id
     id: u32,
     vbs: Vec<VertexBuffer>,
     ibs: Vec<IndexBuffer>,

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -71,16 +71,15 @@ impl Bindable for VertexArrayObject {
 impl Drawable for VertexArrayObject {
     /// Render the VertexArrayObject
     fn draw(&self) {
-        // render buffers depending on index buffers are set or not
+        let vb = &self.vbs[0];
         if self.ibs.len() == 0 {
-            let vb = &self.vbs[0];
             unsafe {
-                gl::DrawArrays(gl::TRIANGLES, 0, vb.size() as i32);
+                gl::DrawArrays(vb.render_type.gl_primitive(), 0, vb.size() as i32);
             }
         } else {
             let ib = &self.ibs[0];
             unsafe {
-                gl::DrawElements(gl::TRIANGLES, ib.size() as i32, gl::UNSIGNED_INT, ptr::null());
+                gl::DrawElements(vb.render_type.gl_primitive(), ib.size() as i32, gl::UNSIGNED_INT, ptr::null());
             }
         }
     }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -75,9 +75,8 @@ impl Drawable for VertexArrayObject {
 
         // render buffers depending on index buffers are set or not
         if self.ibs.len() == 0 {
-            let render_type = self.vbs[0].render_type;
             unsafe {
-                gl::DrawArrays(render_type, 0, count);
+                gl::DrawArrays(self.vbs[0].gl_primitive(), 0, count);
             }
         } else {
             unsafe {

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -33,7 +33,7 @@ impl VertexBuffer {
         }
 
         VertexBuffer {
-            id: id,
+            id,
             count: vertex_data.len() / (num_components as usize),
             num_components: num_components as i32,
             render_type,
@@ -42,6 +42,10 @@ impl VertexBuffer {
 
     pub fn size(&self) -> usize {
         self.count
+    }
+
+    pub fn num_components(&self) -> i32 {
+        self.num_components
     }
 
     pub fn component_size(&self) -> i32 {

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -3,17 +3,18 @@ use std::mem;
 use gl;
 use gl::types::*;
 
+use render::*;
 use render::traits::{Bindable};
 
 pub struct VertexBuffer {
     pub id: u32,
     pub count: u32,
     num_components: i32,
-    pub render_type: GLenum,
+    pub render_type: Primitive,
 }
 
 impl VertexBuffer {
-    pub fn create(vertex_data: &[f32], num_components: u32, render_type: GLenum) -> VertexBuffer {
+    pub fn create(vertex_data: &[f32], num_components: u32, render_type: Primitive) -> VertexBuffer {
         let total_size = vertex_data.len() * mem::size_of::<GLfloat>();
 
         let mut id = 0;
@@ -41,6 +42,10 @@ impl VertexBuffer {
 
     pub fn component_size(&self) -> i32 {
         self.num_components * 4
+    }
+
+    pub fn gl_primitive(&self) -> u32 {
+        self.render_type.gl_primitive()
     }
 }
 

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -8,7 +8,7 @@ use render::traits::{Bindable};
 
 pub struct VertexBuffer {
     pub id: u32,
-    pub count: u32,
+    pub count: usize,
     num_components: i32,
     pub render_type: Primitive,
 }
@@ -34,10 +34,14 @@ impl VertexBuffer {
 
         VertexBuffer {
             id: id,
-            count: (vertex_data.len() as u32) / num_components,
+            count: vertex_data.len() / (num_components as usize),
             num_components: num_components as i32,
             render_type,
         }
+    }
+
+    pub fn size(&self) -> usize {
+        self.count
     }
 
     pub fn component_size(&self) -> i32 {

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -50,6 +50,8 @@ pub trait Window {
 
 /// Trait that defines an OpenGL specific Window
 pub trait OpenGLWindow: Window {
+    /// Basic setup of an OpenGLWindow
+    fn setup(&self);
     /// Returns true if this window is the current one
     fn is_current(&self) -> bool;
     /// Make this window the current one
@@ -162,13 +164,17 @@ impl RenderWindow {
         // load gl functions
         gl::load_with(|s| window.get_proc_address(s) as *const _);
 
-        Ok(RenderWindow {
+        // create instance and initialize the window
+        let render_window = RenderWindow {
             glfw: glfw,
             window: window,
             events: events,
             input_events: VecDeque::new(),
             pressed_buttons: VecDeque::new(),
-        })
+        };
+        render_window.setup();
+
+        Ok(render_window)
     }
 
     pub fn aspect(&self) -> f32 {
@@ -246,6 +252,13 @@ impl Window for RenderWindow {
 
 /// OpenGL version of the render window
 impl OpenGLWindow for RenderWindow {
+    fn setup(&self) {
+        unsafe {
+            gl::DepthFunc(gl::LESS);
+            gl::Enable(gl::DEPTH_TEST);
+        }
+    }
+
     /// Returns true if the window is the current one
     fn is_current(&self) -> bool {
         self.window.is_current()


### PR DESCRIPTION
Add another sample project, a spinning cube (mesh) with basic lighting.

* add `Cube` struct, a primitive mesh
* add `Mesh` object to contain vertices, normals, and indices
* fix `VertexArrayObject` functions to use correct number of components
* add enums to combine GL specific values
* add `Uniform` convert functions for 4x4 and 3x3 matrices