### PR TITLE
Add enums for different OpenGL enums

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -17,11 +17,14 @@ pub struct Size<T> {
     pub height: T,
 }
 
+/// Primitive type to render
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
 pub enum Primitive {
     /// used to render separate triangles
-    Triangles,
+    Triangles = gl::TRIANGLES,
     /// used to render connected triangle strips
-    TriangleStrip,
+    TriangleStrip = gl::TRIANGLE_STRIP,
 }
 
 impl Primitive {
@@ -29,6 +32,56 @@ impl Primitive {
         match *self {
             Primitive::Triangles     => gl::TRIANGLES,
             Primitive::TriangleStrip => gl::TRIANGLE_STRIP,
+        }
+    }
+}
+
+/// Texture format
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u32)]
+pub enum Format {
+    RGB = gl::RGB,
+    RGB8 = gl::RGB8,
+    RGBA = gl::RGBA,
+    RGBA8 = gl::RGBA8,
+}
+
+impl Format {
+    fn gl_format(&self) -> u32 {
+        match *self {
+            Format::RGB   => gl::RGB,
+            Format::RGB8  => gl::RGB8,
+            Format::RGBA  => gl::RGBA,
+            Format::RGBA8 => gl::RGBA8,
+        }
+    }
+}
+
+/// Pixel data type
+#[derive(Debug, Copy, Clone)]
+#[repr(u32)]
+pub enum PixelType {
+    UnsignedByte = gl::UNSIGNED_BYTE,
+    Byte = gl::BYTE,
+    UnsignedShort = gl::UNSIGNED_SHORT,
+    Short = gl::SHORT,
+    UnsignedInt = gl::UNSIGNED_INT,
+    Int = gl::INT,
+    Float = gl::FLOAT,
+    HalfFloat = gl::HALF_FLOAT,
+}
+
+impl PixelType {
+    fn gl_type(&self) -> u32 {
+        match *self {
+            PixelType::UnsignedByte  => gl::UNSIGNED_BYTE,
+            PixelType::Byte          => gl::BYTE,
+            PixelType::UnsignedShort => gl::UNSIGNED_SHORT,
+            PixelType::Short         => gl::SHORT,
+            PixelType::UnsignedInt   => gl::UNSIGNED_INT,
+            PixelType::Int           => gl::INT,
+            PixelType::Float         => gl::FLOAT,
+            PixelType::HalfFloat     => gl::HALF_FLOAT,
         }
     }
 }


### PR DESCRIPTION
Add a few enums to group related OpenGL constants. Enums have their OpenGL values assigned to them.