### PR TITLE
Extend error function with backtrace information

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![crate_type="lib"]
 #![crate_type="dylib"]
 
+extern crate backtrace;
 extern crate cgmath;
 extern crate gl;
 extern crate glfw;


### PR DESCRIPTION
This provides some more information when an error occurs, it returns file, function name and line number.