### PR TITLE
Refactor structs in render module

### DIFF
--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -32,7 +32,7 @@ fn main() {
     // create shader program
     let vertex_file = String::from("./examples/01-spinning-cube/shaders/vertex.glsl");
     let fragment_file = String::from("./examples/01-spinning-cube/shaders/fragment.glsl");
-    let program: Program = Program::compile_from_files(&vertex_file, &fragment_file).unwrap();
+    let mut program: Program = Program::compile_from_files(&vertex_file, &fragment_file).unwrap();
 
     // create vertex data
     let mesh = Mesh::create_cube(Cube::create(1.0)).unwrap();

--- a/examples/02-triangles/main.rs
+++ b/examples/02-triangles/main.rs
@@ -40,7 +40,7 @@ fn main() {
 
     // create vertex data
     let vb = VertexBuffer::create(&VERTICES, 2, Primitive::TriangleStrip);
-    let ib = IndexBuffer::create(&INDICES);
+    let ib = IndexBuffer::create(&INDICES).unwrap();
 
     let mut vao = VertexArrayObject::new().unwrap();
     vao.add_vb(vb);

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -23,7 +23,7 @@ impl Mesh {
         vao.add_vb(VertexBuffer::create(&cube.vertices, 3, Primitive::Triangles));
         vao.add_vb(VertexBuffer::create(&cube.normals, 3, Primitive::Triangles));
         vao.add_vb(VertexBuffer::create(&cube.texcoords, 2, Primitive::Triangles));
-        vao.add_ib(IndexBuffer::create(&cube.indices));
+        vao.add_ib(IndexBuffer::create(&cube.indices)?);
 
         Ok(Mesh {
             vao,
@@ -38,7 +38,7 @@ impl Mesh {
         vao.add_vb(VertexBuffer::create(&plane.vertices, 3, Primitive::Triangles));
         vao.add_vb(VertexBuffer::create(&plane.normals, 3, Primitive::Triangles));
         vao.add_vb(VertexBuffer::create(&plane.texcoords, 2, Primitive::Triangles));
-        vao.add_ib(IndexBuffer::create(&plane.indices));
+        vao.add_ib(IndexBuffer::create(&plane.indices)?);
 
         Ok(Mesh {
             vao,

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -1,18 +1,21 @@
 use cgmath::{Matrix4, Vector3};
 use cgmath::One;
 
-use super::cube::Cube;
-use super::plane::Plane;
+use super::{Cube, Plane};
 
+use math::Color;
 use render::{Primitive, RenderError};
-use render::vertex::VertexArrayObject;
-use render::vertex_buffer::VertexBuffer;
-use render::index_buffer::IndexBuffer;
+use render::{IndexBuffer, VertexBuffer, VertexArrayObject};
 
+/// A basic mesh structure that contains vertex data and some
+/// properties to be used in a scene
 pub struct Mesh {
+    /// the vertex array object
     pub vao: VertexArrayObject,
-    // TODO add a few more properties, local object matrix
+    /// the local model view matrix
     pub model_view: Matrix4<f32>,
+    /// the ambient color of the Mesh
+    pub ambient_color: Color,
 }
 
 impl Mesh {
@@ -27,7 +30,8 @@ impl Mesh {
 
         Ok(Mesh {
             vao,
-            model_view: Matrix4::one()
+            model_view: Matrix4::one(),
+            ambient_color: Color::rgb(1.0, 1.0, 1.0),
         })
     }
 
@@ -42,7 +46,8 @@ impl Mesh {
 
         Ok(Mesh {
             vao,
-            model_view: Matrix4::one()
+            model_view: Matrix4::one(),
+            ambient_color: Color::rgb(1.0, 1.0, 1.0),
         })
     }
 

--- a/src/render/context.rs
+++ b/src/render/context.rs
@@ -159,7 +159,7 @@ pub struct Context {
 }
 
 impl Context {
-    /// Create a new Context,
+    /// Create a new Context
     pub fn new(debug: bool) -> Result<Rc<Context>, OpenGLError> {
         let capabilities = Capabilities::enumerate();
 

--- a/src/render/index_buffer.rs
+++ b/src/render/index_buffer.rs
@@ -3,7 +3,9 @@ use std::mem;
 use gl;
 use gl::types::*;
 
+use render::RenderError;
 use render::traits::{Bindable};
+use render::opengl::get_render_error;
 
 pub struct IndexBuffer {
     pub id: u32,
@@ -11,7 +13,7 @@ pub struct IndexBuffer {
 }
 
 impl IndexBuffer {
-    pub fn create(indices: &[u32]) -> IndexBuffer {
+    pub fn create(indices: &[u32]) -> Result<IndexBuffer, RenderError> {
         let total_size = indices.len() * mem::size_of::<u32>();
 
         let mut id = 0;
@@ -29,10 +31,12 @@ impl IndexBuffer {
             gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, 0);
         }
 
-        IndexBuffer {
+        get_render_error()?;
+
+        Ok(IndexBuffer {
             id,
             count: indices.len(),
-        }
+        })
     }
 
     pub fn num_indices(&self) -> usize {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -74,13 +74,13 @@ pub struct Point2<T> {
 }
 
 impl<T> Point2<T> {
-    /// Creates a new Point with x,y coordinates
-    fn new(x: T, y: T) -> Self {
+    pub fn new(x: T, y: T) -> Self {
         Point2 { x, y }
     }
 }
 
 impl Default for Point2<u32> {
+    /// Creates a new Point with x,y coordinates
     fn default() -> Self {
         Point2 { x: 0, y: 0 }
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -35,7 +35,7 @@ pub struct RenderError {
 /// Generates an appropriate error message for Display
 impl fmt::Display for RenderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", format!("Render Error: {}", self.message ))
+        write!(f, "{}", format!("Render Error: {}", self.message))
     }
 }
 

--- a/src/render/opengl.rs
+++ b/src/render/opengl.rs
@@ -107,10 +107,14 @@ pub fn get_render_error() -> Result<(), RenderError> {
     Err(RenderError { message: errors.join(", ") })
 }
 
+/// A Backtrace frame
 #[derive(Debug, Clone)]
 struct Frame {
+    /// The line number if present
     pub lineno: Option<u32>,
+    /// The function name
     pub name: Option<String>,
+    /// The name of the file
     pub filename: Option<PathBuf>,
 }
 

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -1,16 +1,15 @@
 use cgmath::{Matrix, Matrix3, Matrix4, Point3, Vector2, Vector3};
 
-use math::color::Color;
-
 use gl;
 use gl::types::*;
 
 use std::ptr;
 use std::str;
 
+use math::color::Color;
+
 use super::Size;
-use render::shader::Shader;
-use render::texture::Texture;
+use render::{Shader, Texture};
 use render::traits::Bindable;
 
 /// A shader variable, can be an uniform or attribute
@@ -93,6 +92,7 @@ pub struct Program {
     pub samples: Vec<Sample>,
 }
 
+/// An enum to provide a unified interface for all Uniforms
 #[derive(Debug)]
 pub enum Uniform {
     Color(Color),
@@ -335,7 +335,7 @@ impl Program {
     ///
     /// * `name` - The name of the uniform variable
     /// * `uniform` - The Uniform to set
-    pub fn uniform(&self, name: &str, uniform: Uniform) -> &Self {
+    pub fn uniform(&mut self, name: &str, uniform: Uniform) -> &mut Self {
         if let Some(variable) = self.uniform_by_name(name) {
             let location = variable.location;
             match uniform {

--- a/src/render/shader.rs
+++ b/src/render/shader.rs
@@ -22,6 +22,7 @@ fn get_compile_error(shader: u32) -> String {
     unsafe {
         let mut length: i32 = 0;
         gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut length);
+
         let mut buffer = Vec::with_capacity(length as usize);
         buffer.set_len((length as usize) - 1);
 
@@ -108,13 +109,11 @@ impl Shader {
 
     pub fn create(source: &str, shader_type: GLenum) -> Result<Self, String> {
         match compile_shader(source, shader_type) {
-            Ok(id) => {
-                Ok(Shader {
-                    id,
-                    source: String::from(source),
-                    shader_type,
-                })
-            }
+            Ok(id) => Ok(Shader {
+                id,
+                source: String::from(source),
+                shader_type,
+            }),
             Err(message) => Err(message),
         }
     }

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,6 +1,7 @@
 use std::ptr;
 use gl;
 
+use render::opengl::get_render_error;
 use render::{Format, PixelType, RenderError, Size};
 use render::traits::{Bindable};
 
@@ -43,7 +44,7 @@ pub struct Texture {
     pub id: u32,
     /// Target type of the Texture
     pub target: u32,
-    /// Texture format, internal
+    /// Texture internal format
     pub format: Format,
     /// Texture pixel format
     pub pixel_format: PixelFormat,
@@ -117,8 +118,8 @@ impl Texture {
     /// * `size` - the Size of the texture, best to provide a multiple of 2
     ///
     /// Returns either reference to self or an Error message
-    pub fn set_size(&mut self, size: Size<u32>) -> &mut Self {
-        self.size = size;
+    pub fn set_size(&mut self, size: &Size<u32>) -> Result<&mut Self, RenderError> {
+        self.size = *size;
 
         let format: gl::types::GLenum = self.format.into();
 
@@ -138,7 +139,9 @@ impl Texture {
             gl::GenerateMipmap(self.target);
         }
 
-        self
+        get_render_error()?;
+
+        Ok(self)
     }
 
     /// Enable linear interpolation
@@ -201,7 +204,7 @@ impl Bindable for Texture {
             gl::GetIntegerv(gl::TEXTURE_BINDING_2D, &mut id);
         }
 
-        return self.id == (id as u32);
+        self.id == (id as u32)
     }
 }
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -2,16 +2,16 @@ use std::ptr;
 
 use gl;
 
-use render::RenderError;
+use render::{IndexBuffer, RenderError, VertexBuffer};
 use render::traits::{Bindable, Drawable};
-use render::index_buffer::{IndexBuffer};
-use render::vertex_buffer::{VertexBuffer};
 
 /// A struct to represent a OpenGL vertex array object (VAO)
 pub struct VertexArrayObject {
     /// the OpenGL instance id
     id: u32,
+    /// The list of Vertex Buffers
     vbs: Vec<VertexBuffer>,
+    /// The list of Index Buffers,
     ibs: Vec<IndexBuffer>,
 }
 
@@ -54,7 +54,14 @@ impl Bindable for VertexArrayObject {
         for (i, ref vb) in self.vbs.iter().enumerate() {
             vb.bind();
             unsafe {
-                gl::VertexAttribPointer(i as u32, vb.num_components(), gl::FLOAT, gl::FALSE, stride, ptr::null());
+                gl::VertexAttribPointer(
+                    i as u32,
+                    vb.num_components(),
+                    gl::FLOAT,
+                    gl::FALSE,
+                    stride,
+                    ptr::null(),
+                );
                 gl::EnableVertexAttribArray(i as u32);
             }
             stride += vb.component_size();
@@ -100,7 +107,12 @@ impl Drawable for VertexArrayObject {
         } else {
             let ib = &self.ibs[0];
             unsafe {
-                gl::DrawElements(gl::TRIANGLES, ib.num_indices() as i32, gl::UNSIGNED_INT, ptr::null());
+                gl::DrawElements(
+                    gl::TRIANGLES,
+                    ib.num_indices() as i32,
+                    gl::UNSIGNED_INT,
+                    ptr::null(),
+                );
             }
         }
     }

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -149,8 +149,7 @@ impl RenderWindow {
             Err(_) => return Err("Failed to initialize GLFW".to_string()),
         };
 
-        glfw.window_hint(glfw::WindowHint::ContextVersionMajor(3));
-        glfw.window_hint(glfw::WindowHint::ContextVersionMinor(3));
+        glfw.window_hint(glfw::WindowHint::ContextVersion(3, 2));
         glfw.window_hint(glfw::WindowHint::Resizable(true));
         glfw.window_hint(glfw::WindowHint::OpenGlForwardCompat(true));
         glfw.window_hint(glfw::WindowHint::OpenGlProfile(


### PR DESCRIPTION
This PR refactors / extends a few structs in the render module

* extend Mesh struct to contain ambient color
* refactor `IndexBuffer.create` function to return Result
* some small refactorings