### PR TITLE
Fix setting OpenGL debug callback on OSX

### DIFF
--- a/src/render/context.rs
+++ b/src/render/context.rs
@@ -85,16 +85,18 @@ fn init_debug_callback(context: &Context, synchronous: bool) {
     unsafe impl Send for ContextRawPtr {}
     let context_raw_ptr = ContextRawPtr(&*context);
 
-    unsafe {
-        gl::DebugMessageCallback(callback_wrapper, context_raw_ptr.0 as *const _);
-        gl::DebugMessageControl(
-            gl::DONT_CARE,
-            gl::DONT_CARE,
-            gl::DONT_CARE,
-            0,
-            ptr::null(),
-            gl::TRUE,
-        );
+    if context.capabilities.debug {
+        unsafe {
+            gl::DebugMessageCallback(callback_wrapper, context_raw_ptr.0 as *const _);
+            gl::DebugMessageControl(
+                gl::DONT_CARE,
+                gl::DONT_CARE,
+                gl::DONT_CARE,
+                0,
+                ptr::null(),
+                gl::TRUE,
+            );
+        }
     }
 }
 

--- a/src/render/frame_buffer.rs
+++ b/src/render/frame_buffer.rs
@@ -1,6 +1,5 @@
 use render::{RenderError, Size};
 use render::traits::{Bindable};
-use render::opengl::get_render_error;
 use render::texture::Texture;
 
 /// A general purpose frame buffer to store pixel data into
@@ -45,8 +44,6 @@ impl FrameBuffer {
             gl::GenFramebuffers(1, &mut id);
         }
 
-        get_render_error()?;
-
         Ok(FrameBuffer {
             id,
             size: Size::default(),
@@ -71,7 +68,6 @@ impl FrameBuffer {
             );
         }
 
-        get_render_error()?;
         check_status()?;
 
         Ok(self)
@@ -95,7 +91,6 @@ impl FrameBuffer {
             );
         }
 
-        get_render_error()?;
         check_status()?;
 
         Ok(self)

--- a/src/render/index_buffer.rs
+++ b/src/render/index_buffer.rs
@@ -5,7 +5,6 @@ use gl::types::*;
 
 use render::RenderError;
 use render::traits::{Bindable};
-use render::opengl::get_render_error;
 
 pub struct IndexBuffer {
     pub id: u32,
@@ -30,8 +29,6 @@ impl IndexBuffer {
             );
             gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, 0);
         }
-
-        get_render_error()?;
 
         Ok(IndexBuffer {
             id,

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -160,6 +160,11 @@ fn get_link_error(program: u32) -> String {
     unsafe {
         let mut length: GLint = 0;
         gl::GetShaderiv(program, gl::INFO_LOG_LENGTH, &mut length);
+
+        if length == 0 {
+            return String::new();
+        }
+
         let mut buffer = Vec::with_capacity(length as usize);
         buffer.set_len((length as usize) - 1);
 

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -1,7 +1,6 @@
 use std::ptr;
 use gl;
 
-use render::opengl::get_render_error;
 use render::{Format, PixelType, RenderError, Size};
 use render::traits::{Bindable};
 
@@ -138,8 +137,6 @@ impl Texture {
 
             gl::GenerateMipmap(self.target);
         }
-
-        get_render_error()?;
 
         Ok(self)
     }


### PR DESCRIPTION
On OSX the OpenGL version is often times lower than on other systems, the OpenGL debug callback requires a more recent version (>= 4.2). Therefore the debug callback is only set up if it's actually supported.

* remove calls to `get_render_error` function, it would require to get called after every GL function