### PR TITLE
Add Shader Type enum

### DIFF
--- a/examples/04-spotlight/main.rs
+++ b/examples/04-spotlight/main.rs
@@ -101,7 +101,7 @@ fn main() {
         // render light first
         light_frame_buffer.bind();
         window.set_viewport(&Point2::default(), &light_depth_texture.size);
-        window.clear(1.0, 1.0, 1.0, 1.0);
+        window.clear(0.0, 0.0, 0.0, 1.0);
         window.clear_depth(1.0);
         // window.set_cullmode(CullMode::Front);
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,7 @@ pub use self::context::Context;
 pub use self::frame_buffer::FrameBuffer;
 pub use self::index_buffer::IndexBuffer;
 pub use self::program::{Program, Uniform};
-pub use self::shader::Shader;
+pub use self::shader::{Shader, ShaderType};
 pub use self::spot_light::Spotlight;
 pub use self::texture::Texture;
 pub use self::traits::*;

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -9,7 +9,7 @@ use std::str;
 use math::color::Color;
 
 use super::Size;
-use render::{Shader, Texture};
+use render::{Shader, ShaderType, Texture};
 use render::traits::Bindable;
 
 /// A shader variable, can be an uniform or attribute
@@ -319,11 +319,11 @@ pub fn link_program(vertex_shader: Shader, pixel_shader: Shader) -> Result<Progr
 
 impl Program {
     pub fn compile_from_files(vertex_file: &str, fragment_file: &str) -> Result<Program, String> {
-        let vertex_shader = match Shader::from_file(vertex_file, gl::VERTEX_SHADER) {
+        let vertex_shader = match Shader::from_file(vertex_file, ShaderType::Vertex) {
             Ok(shader) => shader,
             Err(e) => return Err(e),
         };
-        let fragment_shader = match Shader::from_file(fragment_file, gl::FRAGMENT_SHADER) {
+        let fragment_shader = match Shader::from_file(fragment_file, ShaderType::Fragment) {
             Ok(shader) => shader,
             Err(e) => return Err(e),
         };


### PR DESCRIPTION
This PR adds the `ShaderType` enum to group shader type specific GL values, e.g. fragment, vertex, geometry.