### PR TITLE
Refactor spotlight example

### DIFF
--- a/examples/04-spotlight/main.rs
+++ b/examples/04-spotlight/main.rs
@@ -23,13 +23,13 @@ fn main() {
         .expect("Failed to create Render Window");
 
     window.enable(Capability::DepthTest);
-    window.disable(Capability::CullFace);
+    window.enable(Capability::CullFace);
     window.set_cullmode(CullMode::Back);
 
     // create shader program
     let vertex_file = String::from("./examples/04-spotlight/shaders/scene_vertex.glsl");
     let fragment_file = String::from("./examples/04-spotlight/shaders/scene_fragment.glsl");
-    let mut display_program: Program = Program::compile_from_files(&vertex_file, &fragment_file).unwrap();
+    let mut scene_program: Program = Program::compile_from_files(&vertex_file, &fragment_file).unwrap();
 
     let vertex_file = String::from("./examples/04-spotlight/shaders/light_vertex.glsl");
     let fragment_file = String::from("./examples/04-spotlight/shaders/light_fragment.glsl");
@@ -37,7 +37,7 @@ fn main() {
 
     let light_pos = point3(-2.5, 0.0, 1.0);
 
-    let cube = Node::new(Mesh::create_cube(Cube::create(0.75), Color::rgb(1.0, 1.0, 1.0)).unwrap());
+    let mut cube = Node::new(Mesh::create_cube(Cube::create(0.75), Color::rgb(1.0, 1.0, 1.0)).unwrap());
     let mut plane = Node::new(Mesh::create_plane(Plane::create(10.0, 10.0), Color::rgb(1.0, 1.0, 1.0)).unwrap());
 
     plane.translate(Vector3{ x: 0.0, y: -3.0, z: 0.0});
@@ -50,16 +50,14 @@ fn main() {
     camera
         .perspective(60.0, window.aspect(), 0.1, 80.0)
         .lookat(
-            point3(0.0, 4.0, -3.5),
-            point3(0.0, 0.0, 0.0),
+            point3(0.0, 6.0, -5.5),
+            point3(0.0, 1.0, -1.0),
             vec3(0.0, 1.0, 0.0)
         );
 
-    let light_pos = point3(-2.5, 0.0, 1.0);
-
     let mut spot_light = Spotlight::new();
     spot_light.set_lookat(
-        light_pos.clone(),
+        point3(-0.5, 8.0, 2.0),
         point3(0.5, 0.0, 1.0),
         vec3(0.0, 1.0, 0.0),
     );
@@ -73,18 +71,18 @@ fn main() {
     light_texture.nearest();
     light_texture.unbind();
 
-    let mut light_depth_texture = Texture::create_depth_texture().unwrap();
-    light_depth_texture.bind();
-    light_depth_texture.set_size(&light_texture_size).unwrap();
-    light_depth_texture.clamp_to_edge();
-    light_depth_texture.nearest();
-    light_depth_texture.unbind();
+    let mut shadow_texture = Texture::create_depth_texture().unwrap();
+    shadow_texture.bind();
+    shadow_texture.set_size(&light_texture_size).unwrap();
+    shadow_texture.clamp_to_edge();
+    shadow_texture.nearest();
+    shadow_texture.unbind();
 
-    let mut light_frame_buffer = FrameBuffer::create().unwrap();
-    light_frame_buffer.bind();
-    light_frame_buffer.set_texture(&light_texture).expect("Set texture failed");
-    light_frame_buffer.set_depth_buffer(&light_depth_texture).expect("Set depth buffer failed");
-    light_frame_buffer.unbind();
+    let mut shadow_frame_buffer = FrameBuffer::create().unwrap();
+    shadow_frame_buffer.bind();
+    shadow_frame_buffer.set_texture(&light_texture).expect("Set texture failed");
+    shadow_frame_buffer.set_depth_buffer(&shadow_texture).expect("Set depth buffer failed");
+    shadow_frame_buffer.unbind();
 
     let start_time = Instant::now();
 
@@ -99,29 +97,26 @@ fn main() {
 
         //----------------------------------------------------------
         // render light first
-        light_frame_buffer.bind();
-        window.set_viewport(&Point2::default(), &light_depth_texture.size);
+        shadow_frame_buffer.bind();
+        window.set_viewport(&Point2::default(), &shadow_texture.size);
         window.clear(0.0, 0.0, 0.0, 1.0);
         window.clear_depth(1.0);
-        // window.set_cullmode(CullMode::Front);
+        window.set_cullmode(CullMode::Front);
 
         light_program.bind();
         light_program
             .uniform("u_lightView", spot_light.view.into())
-            .uniform("u_lightProj", spot_light.projection.into())
-            .uniform("u_lightPos", spot_light.pos.into());
+            .uniform("u_lightProj", spot_light.projection.into());
 
         // render all nodes
         scene.nodes(&mut |node| {
             light_program
-                .uniform("u_ambientColor", Color::rgb(0.1, 0.1, 0.1).into())
-                .uniform("u_model", node.model_view.into())
-                .uniform("u_normalModel", node.normal_view().into());
+                .uniform("u_model", node.model_view.into());
 
             node.draw();
         });
 
-        light_frame_buffer.unbind();
+        shadow_frame_buffer.unbind();
 
 
         //----------------------------------------------------------
@@ -131,26 +126,20 @@ fn main() {
         window.clear(0.0, 0.0, 0.0, 1.0);
         window.clear_depth(1.0);
 
-        display_program.bind();
-        display_program
+        scene_program.bind();
+        scene_program
             .uniform("u_camProj", camera.projection.into())
             .uniform("u_camView", camera.view.into())
             .uniform("u_lightView", spot_light.view.into())
             .uniform("u_lightRot", normal_matrix(&spot_light.view).into())
             .uniform("u_lightProj", spot_light.projection.into())
-            .sampler("u_sShadowMap", 0, &light_depth_texture)
+            .sampler("u_sShadowMap", 0, &shadow_texture)
             .uniform("u_shadowMapSize", light_texture_size.into());
 
         // render plane!
         let model_view = camera.view * plane.model_view;
         let model_view_proj = camera.projection * model_view;
         let normal_matrix: Matrix3<f32> = convert_to_matrix3(&model_view).invert().unwrap().transpose();
-
-        display_program
-            .uniform("u_modelView", model_view.into())
-            .uniform("u_modelViewProjection", model_view_proj.into())
-            .uniform("u_normalMatrix", normal_matrix.into())
-            .uniform("u_objectColor", Color::rgb(0.4, 0.8, 0.25).into());
 
         plane.draw();
 
@@ -164,15 +153,15 @@ fn main() {
 
         // render all nodes
         scene.nodes(&mut |node| {
-            display_program
-                .uniform("u_ambientColor", Color::rgb(1.0, 1.0, 1.0).into())
+            scene_program
+                .uniform("u_ambientColor", Color::rgb(0.1, 0.1, 0.1).into())
                 .uniform("u_model", node.model_view.into())
                 .uniform("u_normalModel", node.normal_view().into());
 
             node.draw();
         });
 
-        display_program.unbind();
+        scene_program.unbind();
 
 
         //----------------------------------------------------------

--- a/examples/04-spotlight/shaders/light_fragment.glsl
+++ b/examples/04-spotlight/shaders/light_fragment.glsl
@@ -2,8 +2,6 @@
 
 in vec4 vWorldPosition;
 
-uniform vec3 u_lightPos;
-
 out vec4 out_color;
 
 void main() {

--- a/examples/04-spotlight/shaders/light_vertex.glsl
+++ b/examples/04-spotlight/shaders/light_vertex.glsl
@@ -7,6 +7,7 @@ uniform mat4 u_lightProj;
 uniform mat4 u_model;
 
 layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 normal;
 
 void main(void) {
     vWorldPosition = u_lightView * u_model * vec4(position, 1.0);

--- a/examples/04-spotlight/shaders/scene_fragment.glsl
+++ b/examples/04-spotlight/shaders/scene_fragment.glsl
@@ -6,7 +6,6 @@ in vec4 vWorldPosLightSpace;
 
 uniform mat4 u_lightView;
 uniform mat3 u_lightRot;
-uniform vec3 u_lightPos;
 uniform mat4 u_model;
 
 uniform vec4 u_ambientColor;
@@ -83,8 +82,8 @@ vec3 gamma(vec3 color, float gammaValue) {
 void main(void) {
     vec3 worldNormal = normalize(vWorldNormal);
 
-    vec3 u_lightPos = (u_lightView * vWorldPosition).xyz;
-    vec3 lightPosNormal = normalize(u_lightPos);
+    vec3 lightPos = (u_lightView * vWorldPosition).xyz;
+    vec3 lightPosNormal = normalize(lightPos);
     vec3 lightSurfaceNormal = u_lightRot * worldNormal;
     vec2 lightDeviceNormal = vWorldPosLightSpace.xy / vWorldPosLightSpace.w;
     vec2 lightUV = (lightDeviceNormal * 0.5) + 0.5;
@@ -92,16 +91,16 @@ void main(void) {
     // shadow calculation
     float bias = 0.001;
     // float lightDepth1 = texture2D(u_sShadowMap, lightUV).r;
-    // float lightDepth2 = clamp(length(u_lightPos) / 40.0, 0.0, 1.0);
+    // float lightDepth2 = clamp(length(lightPos) / 40.0, 0.0, 1.0);
     // float illuminated = step(lightDepth2, lightDepth1 + bias);
-    float lightDepth = clamp(length(u_lightPos) / 40.0, 0.0, 1.0)  -bias;
+    float lightDepth = clamp(length(lightPos) / 40.0, 0.0, 1.0)  -bias;
     float illuminated = pcfLinear(u_sShadowMap, u_shadowMapSize, lightUV, lightDepth);
 
     vec3 excident = (
       u_ambientColor.rgb +
       lambert(lightSurfaceNormal, -lightPosNormal) *
       influence(lightPosNormal, 70.0, 55.0) *
-      attenuation(u_lightPos) *
+      attenuation(lightPos) *
       illuminated
     );
 

--- a/examples/04-spotlight/shaders/scene_vertex.glsl
+++ b/examples/04-spotlight/shaders/scene_vertex.glsl
@@ -12,7 +12,8 @@ uniform mat4 u_lightProj;
 uniform mat4 u_model;
 uniform mat3 u_normalModel;
 
-in vec3 position, normal;
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 normal;
 
 void main(void) {
     // transform position to world space

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -105,6 +105,7 @@ pub enum Uniform {
     Float(f32),
     Float2(f32, f32),
     Float3(f32, f32, f32),
+    Integer(i32),
     Mat3(Matrix3<f32>),
     Mat4(Matrix4<f32>),
     Vec2(Vector2<f32>),
@@ -335,8 +336,14 @@ pub fn link_program(vertex_shader: Shader, pixel_shader: Shader) -> Result<Progr
         samples: Vec::new(),
     };
 
-    println!("UNIFORMS: {:?}", program.uniforms);
-    println!("ATTRIBUTES: {:?}", program.attributes);
+    println!("UNIFORMS");
+    for uniform in &program.uniforms {
+        println!("  {:?}", uniform);
+    }
+    println!("ATTRIBUTES");
+    for attribute in &program.attributes {
+        println!("  {:?}", attribute);
+    }
 
     Ok(program)
 }
@@ -372,6 +379,7 @@ impl Program {
                 Uniform::Float(v) => Program::uniform1f(location, v),
                 Uniform::Float2(x, y) => Program::uniform2f(location, x, y),
                 Uniform::Float3(x, y, z) => Program::uniform3f(location, x, y, z),
+                Uniform::Integer(i) => Program::uniform1i(location, i),
                 Uniform::Mat3(m) => Program::matrix3(location, &m),
                 Uniform::Mat4(m) => Program::matrix4(location, &m),
                 Uniform::Vec2(v) => Program::uniform2f(location, v.x, v.y),
@@ -379,6 +387,8 @@ impl Program {
                 Uniform::Point3(p) => Program::uniform3f(location, p.x, p.y, p.z),
                 Uniform::Size(x, y) => Program::uniform2f(location, x, y),
             }
+        } else {
+            panic!("Unknown uniform name given: {}", name);
         }
         self
     }
@@ -452,6 +462,12 @@ impl Program {
                 z as GLfloat,
                 w as GLfloat,
             )
+        }
+    }
+
+    pub fn uniform1i(location: i32, value: i32) {
+        unsafe {
+            gl::Uniform1i(location, value);
         }
     }
 

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -8,6 +8,7 @@ use render::traits::{Bindable};
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 pub enum PixelFormat {
+    RGB = gl::RGB,
     RGBA = gl::RGBA,
     BGRA = gl::BGRA,
     DepthComponent = gl::DEPTH_COMPONENT,
@@ -17,6 +18,7 @@ pub enum PixelFormat {
 impl From<PixelFormat> for gl::types::GLenum {
     fn from(pixel_format: PixelFormat) -> Self {
         match pixel_format {
+            PixelFormat::RGB => gl::RGB,
             PixelFormat::RGBA => gl::RGBA,
             PixelFormat::BGRA => gl::BGRA,
             PixelFormat::DepthComponent => gl::DEPTH_COMPONENT,
@@ -28,6 +30,7 @@ impl From<PixelFormat> for gl::types::GLenum {
 impl From<gl::types::GLenum> for PixelFormat {
     fn from(pixel_format: gl::types::GLenum) -> Self {
         match pixel_format {
+            gl::RGB => PixelFormat::RGB,
             gl::RGBA => PixelFormat::RGBA,
             gl::BGRA => PixelFormat::BGRA,
             gl::DEPTH_COMPONENT => PixelFormat::DepthComponent,
@@ -69,7 +72,7 @@ impl Texture {
             id,
             target,
             format: Format::RGB,
-            pixel_format: PixelFormat::BGRA,
+            pixel_format: PixelFormat::RGB,
             size: Size::default(),
             pixel_type: PixelType::UnsignedByte,
         };
@@ -96,7 +99,7 @@ impl Texture {
             target,
             format: Format::DepthComponent,
             pixel_format: PixelFormat::DepthComponent,
-            size: Size { width: 0, height: 0 },
+            size: Size::default(),
             pixel_type: PixelType::Float,
         };
 


### PR DESCRIPTION
This PR refactors the spot light example

* something is rendered now
* remove unused Shader variables, not setting Program uniforms
* rename variable
* adjust positions in Camera and Spotlight
* add Program uniform for Integer