### PR TITLE
Refactor Bindable methods to be mutable

### DIFF
--- a/examples/01-spinning-cube/main.rs
+++ b/examples/01-spinning-cube/main.rs
@@ -36,7 +36,7 @@ fn main() {
     let mut program: Program = Program::compile_from_files(&vertex_file, &fragment_file).unwrap();
 
     // create vertex data
-    let mesh = Mesh::create_cube(Cube::create(1.0), Color::rgb(1.0, 1.0, 1.0)).unwrap();
+    let mut mesh = Mesh::create_cube(Cube::create(1.0), Color::rgb(1.0, 1.0, 1.0)).unwrap();
 
     let start_time = Instant::now();
 

--- a/examples/04-spotlight/main.rs
+++ b/examples/04-spotlight/main.rs
@@ -7,7 +7,8 @@ extern crate noire;
 extern crate notify;
 
 use cgmath::*;
-use std::time::Instant;
+use std::error::Error;
+use std::time::{Instant};
 
 use noire::math::*;
 use noire::math::{Camera, Color};
@@ -17,7 +18,7 @@ use noire::render::traits::*;
 use noire::render::{Capability, CullMode, Point2, Size};
 use noire::render::{OpenGLWindow, RenderWindow, Window};
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     let window_size = Size::new(1024, 1024);
     let mut window = RenderWindow::create(&window_size, "Hello This is window")
         .expect("Failed to create Render Window");
@@ -42,8 +43,8 @@ fn main() {
     plane.translate(vec3(0.0, -1.0, 0.0));
 
     let mut scene = Scene::new();
-    scene.add_node(&cube);
-    scene.add_node(&plane);
+    scene.add_node(&mut cube);
+    scene.add_node(&mut plane);
 
     let mut camera = Camera::new();
     camera
@@ -72,7 +73,7 @@ fn main() {
     shadow_texture.nearest();
     shadow_texture.unbind();
 
-    let screen_rect = ScreenRect::create(&shadow_texture);
+    // let mut screen_rect = ScreenRect::new().unwrap();
 
     let mut shadow_frame_buffer = FrameBuffer::create().unwrap();
     shadow_frame_buffer.set_depth_buffer(&shadow_texture).expect("Set depth buffer failed");
@@ -143,7 +144,7 @@ fn main() {
         scene_program.unbind();
         shadow_texture.unbind();
 
-        // screen_rect.render(&window, &Point2::default(), &Size::new(384, 384));
+        // screen_rect.render(&window, &Point2::default(), &Size::new(384, 384), &mut shadow_texture);
 
         //----------------------------------------------------------
         // display everything on screen
@@ -152,7 +153,7 @@ fn main() {
         // handle events
         window.poll_events();
         if window.should_close() {
-            return;
+            return Ok(());
         }
     }
 }

--- a/examples/filewatch.rs
+++ b/examples/filewatch.rs
@@ -10,10 +10,10 @@ use std::time::Duration;
 fn watch_files(files: &Vec<String>) -> notify::Result<()> {
     let (tx, rx) = channel();
 
-    let mut watcher: RecommendedWatcher = try!(Watcher::new(tx, Duration::from_millis(125)));
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(125))?;
 
     for file in files {
-        try!(watcher.watch(&file, RecursiveMode::NonRecursive));
+        watcher.watch(&file, RecursiveMode::NonRecursive)?;
     }
 
     loop {

--- a/src/mesh/node.rs
+++ b/src/mesh/node.rs
@@ -35,7 +35,7 @@ impl Node {
 }
 
 impl Drawable for Node {
-    fn draw(&self) {
+    fn draw(&mut self) {
         self.mesh.vao.bind();
         self.mesh.vao.draw();
         self.mesh.vao.unbind();

--- a/src/mesh/scene.rs
+++ b/src/mesh/scene.rs
@@ -3,7 +3,7 @@ use mesh::Node;
 /// Stores objects in a basic manner
 pub struct Scene<'a> {
     /// the list of nodes
-    nodes: Vec<&'a Node>,
+    nodes: Vec<&'a mut Node>,
 }
 
 impl<'a> Scene<'a> {
@@ -13,14 +13,14 @@ impl<'a> Scene<'a> {
     }
 
     /// Adds a node to the scene
-    pub fn add_node(&mut self, node: &'a Node) -> &mut Self {
+    pub fn add_node(&mut self, node: &'a mut Node) -> &mut Self {
         self.nodes.push(node);
         self
     }
 
     /// Iterate over all scene meshes, allow to set callback
     pub fn nodes<F>(&mut self, callback: &mut F)
-    where F: FnMut(&Node) {
+    where F: FnMut(&mut Node) {
         for node in self.nodes.iter_mut() {
             callback(node);
         }

--- a/src/mesh/screen_rect.rs
+++ b/src/mesh/screen_rect.rs
@@ -3,13 +3,11 @@ use render::{Point2, Primitive, RenderError, Size};
 use render::{Program, ProgramError, Shader, ShaderType, Texture, Uniform};
 use render::{Bindable, Capability, RenderWindow, OpenGLWindow};
 
-pub struct ScreenRect<'a> {
+pub struct ScreenRect {
     /// holds all vertex information
     pub vao: VertexArrayObject,
     /// the program to render the Quad with
     pub program: Program,
-    /// The texture reference to render
-    pub texture: &'a Texture,
 }
 
 fn create_vertex_shader() -> Shader {
@@ -78,8 +76,8 @@ fn create_texcoords() -> Vec<f32> {
     ]
 }
 
-impl<'a> ScreenRect<'a> {
-    pub fn create(texture: &'a Texture) -> Result<Self, RenderError> {
+impl ScreenRect {
+    pub fn new() -> Result<Self, RenderError> {
         let mut vao = VertexArrayObject::new()?;
 
         vao.add_vb(VertexBuffer::create(&create_vertices(), 2, Primitive::Triangles));
@@ -93,12 +91,12 @@ impl<'a> ScreenRect<'a> {
         Ok(ScreenRect {
             vao,
             program,
-            texture,
         })
     }
 
     /// Renders the screen rect
-    pub fn render(&mut self, window: &RenderWindow, point: &Point2<u32>, size: &Size<u32>) -> &mut Self {
+    pub fn render(&mut self, window: &RenderWindow, point: &Point2<u32>, size: &Size<u32>, texture: &mut Texture) -> &mut Self {
+        texture.bind();
         self.bind();
         window.set_viewport(&point, &size);
         window.disable(Capability::DepthTest);
@@ -111,23 +109,22 @@ impl<'a> ScreenRect<'a> {
         window.enable(Capability::DepthTest);
         window.reset_viewport();
         self.unbind();
+        texture.unbind();
 
         self
     }
 }
 
-impl<'a> Bindable for ScreenRect<'a> {
-    fn bind(&self) -> &Self {
-        self.texture.bind();
+impl Bindable for ScreenRect {
+    fn bind(&mut self) -> &mut Self {
         self.program.bind();
         self.vao.bind();
         self
     }
 
-    fn unbind(&self) -> &Self {
+    fn unbind(&mut self) -> &mut Self {
         self.vao.unbind();
         self.program.unbind();
-        self.texture.unbind();
         self
     }
 

--- a/src/render/frame_buffer.rs
+++ b/src/render/frame_buffer.rs
@@ -98,14 +98,14 @@ impl FrameBuffer {
 }
 
 impl Bindable for FrameBuffer {
-    fn bind(&self) -> &Self {
+    fn bind(&mut self) -> &mut Self {
         unsafe {
             gl::BindFramebuffer(gl::FRAMEBUFFER, self.id);
         }
         self
     }
 
-    fn unbind(&self) -> &Self {
+    fn unbind(&mut self) -> &mut Self {
         unsafe {
             gl::BindFramebuffer(gl::FRAMEBUFFER, 0);
         }

--- a/src/render/index_buffer.rs
+++ b/src/render/index_buffer.rs
@@ -42,14 +42,14 @@ impl IndexBuffer {
 }
 
 impl Bindable for IndexBuffer {
-    fn bind(&self) -> &Self {
+    fn bind(&mut self) -> &mut Self {
         unsafe {
             gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, self.id);
         }
         self
     }
 
-    fn unbind(&self) -> &Self {
+    fn unbind(&mut self) -> &mut Self {
         unsafe {
             gl::BindBuffer(gl::ELEMENT_ARRAY_BUFFER, 0);
         }

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -43,7 +43,7 @@ pub struct Sample {
 }
 
 impl Bindable for Sample {
-    fn bind(&self) -> &Self {
+    fn bind(&mut self) -> &mut Self {
         unsafe {
             gl::ActiveTexture(gl::TEXTURE0 + self.unit);
             gl::BindTexture(gl::TEXTURE_2D, self.id);
@@ -51,7 +51,7 @@ impl Bindable for Sample {
         self
     }
 
-    fn unbind(&self) -> &Self {
+    fn unbind(&mut self) -> &mut Self {
         unsafe {
             gl::ActiveTexture(gl::TEXTURE0 + self.unit);
             gl::BindTexture(gl::TEXTURE_2D, 0);
@@ -391,7 +391,7 @@ impl Program {
     /// * `name` - The name associated with the texture in the program
     /// * `unit` - The unit slot to attach the texture
     /// * `texture` - The texture reference to use
-    pub fn sampler(&mut self, name: &str, unit: u32, texture: &Texture) -> &mut Self {
+    pub fn sampler(&mut self, name: &str, unit: u32, texture: &mut Texture) -> &mut Self {
         texture.bind();
         self.uniform(name, Uniform::Integer(unit as i32));
 
@@ -488,14 +488,14 @@ impl Program {
 }
 
 impl Bindable for Program {
-    fn bind(&self) -> &Self {
+    fn bind(&mut self) -> &mut Self {
         unsafe {
             gl::UseProgram(self.id);
         }
         self
     }
 
-    fn unbind(&self) -> &Self {
+    fn unbind(&mut self) -> &mut Self {
         unsafe {
             gl::UseProgram(0);
         }

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -180,7 +180,7 @@ impl Texture {
 }
 
 impl Bindable for Texture {
-    fn bind(&self) -> &Self {
+    fn bind(&mut self) -> &mut Self {
         // debug_assert!(!self.bound());
 
         unsafe {
@@ -190,7 +190,7 @@ impl Bindable for Texture {
         self
     }
 
-    fn unbind(&self) -> &Self {
+    fn unbind(&mut self) -> &mut Self {
         // debug_assert!(self.bound());
 
         unsafe {

--- a/src/render/traits.rs
+++ b/src/render/traits.rs
@@ -2,14 +2,14 @@
 /// they can be used.
 pub trait Bindable {
     /// Binds the instance, should map the associated OpenGL bind function
-    fn bind(&self) -> &Self;
+    fn bind(&mut self) -> &mut Self;
     /// Unbinds the instance, release the resource
-    fn unbind(&self) -> &Self;
+    fn unbind(&mut self) -> &mut Self;
     /// Checks if the resource is bound
     fn bound(&self) -> bool;
 }
 
 /// Trait to render something
 pub trait Drawable {
-    fn draw(&self);
+    fn draw(&mut self);
 }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -45,13 +45,14 @@ impl VertexArrayObject {
 }
 
 impl Bindable for VertexArrayObject {
-    fn bind(&self) -> &Self {
+    /// Binds the resource
+    fn bind(&mut self) -> &mut Self {
         unsafe {
             gl::BindVertexArray(self.id);
         }
 
         let mut stride = 0;
-        for (i, ref vb) in self.vbs.iter().enumerate() {
+        for (i, vb) in self.vbs.iter_mut().enumerate() {
             vb.bind();
             unsafe {
                 gl::VertexAttribPointer(
@@ -67,14 +68,15 @@ impl Bindable for VertexArrayObject {
             stride += vb.component_size();
         }
 
-        for ref ib in self.ibs.iter() {
+        for ib in self.ibs.iter_mut() {
             ib.bind();
         }
         self
     }
 
-    fn unbind(&self) -> &Self {
-        for (i, ref vb) in self.vbs.iter().enumerate() {
+    /// Unbinds / frees the resource
+    fn unbind(&mut self) -> &mut Self {
+        for (i, vb) in self.vbs.iter_mut().enumerate() {
             vb.unbind();
             unsafe {
                 gl::DisableVertexAttribArray(i as u32);
@@ -82,6 +84,10 @@ impl Bindable for VertexArrayObject {
         }
         unsafe {
             gl::BindVertexArray(0);
+        }
+
+        for ib in self.ibs.iter_mut() {
+            ib.unbind();
         }
         self
     }
@@ -98,7 +104,7 @@ impl Bindable for VertexArrayObject {
 
 impl Drawable for VertexArrayObject {
     /// Render the VertexArrayObject
-    fn draw(&self) {
+    fn draw(&mut self) {
         let vb = &self.vbs[0];
         if self.ibs.is_empty() {
             unsafe {

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -58,14 +58,14 @@ impl VertexBuffer {
 }
 
 impl Bindable for VertexBuffer {
-    fn bind(&self) -> &Self {
+    fn bind(&mut self) -> &mut Self {
         unsafe {
             gl::BindBuffer(gl::ARRAY_BUFFER, self.id);
         }
         self
     }
 
-    fn unbind(&self) -> &Self {
+    fn unbind(&mut self) -> &mut Self {
         unsafe {
             gl::BindBuffer(gl::ARRAY_BUFFER, 0);
         }


### PR DESCRIPTION
This PR adjusts the current Bindable trait to be mutable.

* change `Bindable` methods to be mutable
* refactor `ScreenRect` render method to accept Texture instead of storing reference
* adjust Scene render callback