### PR TITLE
Refactor capabilities handling

### DIFF
--- a/src/render/capabilities.rs
+++ b/src/render/capabilities.rs
@@ -4,6 +4,27 @@ use std::fmt::Display;
 
 use gl;
 
+#[derive(Debug)]
+pub struct CapabilityError {
+    /// The error message
+    pub error: String,
+}
+
+impl CapabilityError {
+    /// Construct a new error
+    pub fn new(error: &str) -> Self {
+        CapabilityError {
+            error: error.to_string()
+        }
+    }
+}
+
+impl fmt::Display for CapabilityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Capability error: {}", self.error)
+    }
+}
+
 /// A struct representing OpenGL capabilities and properties
 pub struct Capabilities {
     /// The OpenGL Vendor string

--- a/src/render/context.rs
+++ b/src/render/context.rs
@@ -163,7 +163,7 @@ pub struct Context {
 impl Context {
     /// Create a new Context
     pub fn new(debug: bool) -> Result<Rc<Context>, OpenGLError> {
-        let capabilities = Capabilities::enumerate();
+        let capabilities = Capabilities::enumerate().map_err(|e| OpenGLError(e.to_string()))?;
 
         let debug_callback = if debug && capabilities.debug {
             Some(Box::new(default_debug_callback) as DebugCallback)


### PR DESCRIPTION
When enumerating different Open GL properties, such as version, renderer, name etc, a `CapabilityError` struct is now used. The different functions return a `Result` to provide better error handling.