### PR TITLE
Add vertex type to use with VertexBuffer

### DIFF
--- a/examples/02-triangles/main.rs
+++ b/examples/02-triangles/main.rs
@@ -28,10 +28,10 @@ fn main() {
     let mut program: Program = Program::compile_from_files(&vertex_file, &fragment_file).unwrap();
 
     // create vertex data
-    let vb = VertexBuffer::create(&VERTICES, 2, Primitive::TriangleStrip);
+    let vb = VertexBuffer::create(&VERTICES, 2);
     let ib = IndexBuffer::create(&INDICES).unwrap();
 
-    let mut vao = VertexArrayObject::new().unwrap();
+    let mut vao = VertexArrayObject::new(Primitive::TriangleStrip).unwrap();
     vao.add_vb(vb);
     vao.add_ib(ib);
 

--- a/examples/03-raymarching/main.rs
+++ b/examples/03-raymarching/main.rs
@@ -57,8 +57,8 @@ fn main() {
         .set_position(point3(0.0, 2.0, 20.0));
 
     // create vertex data
-    let vb = VertexBuffer::create(&VERTICES, 2, Primitive::TriangleStrip);
-    let mut vao = VertexArrayObject::new().unwrap();
+    let vb = VertexBuffer::create(&VERTICES, 2);
+    let mut vao = VertexArrayObject::new(Primitive::TriangleStrip).unwrap();
     vao.add_vb(vb);
 
     let mut last_pos = Pos { x: 0, y: 0 };

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -16,11 +16,10 @@ pub struct Mesh {
 impl Mesh {
     /// Creates a Mesh object from a Cube
     pub fn create_cube(cube: Cube, color: Color) -> Result<Mesh, RenderError> {
-        let mut vao = VertexArrayObject::new()?;
+        let mut vao = VertexArrayObject::new(Primitive::Triangles)?;
 
-        vao.add_vb(VertexBuffer::create(&cube.vertices, 3, Primitive::Triangles));
-        vao.add_vb(VertexBuffer::create(&cube.normals, 3, Primitive::Triangles));
-        // vao.add_vb(VertexBuffer::create(&cube.texcoords, 2, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&cube.vertices, 3));
+        vao.add_vb(VertexBuffer::create(&cube.normals, 3));
         vao.add_ib(IndexBuffer::create(&cube.indices)?);
 
         Ok(Mesh {
@@ -31,11 +30,10 @@ impl Mesh {
 
     /// Creates a Mesh object from a Plane
     pub fn create_plane(plane: Plane, color: Color) -> Result<Mesh, RenderError> {
-        let mut vao = VertexArrayObject::new()?;
+        let mut vao = VertexArrayObject::new(Primitive::Triangles)?;
 
-        vao.add_vb(VertexBuffer::create(&plane.vertices, 3, Primitive::Triangles));
-        vao.add_vb(VertexBuffer::create(&plane.normals, 3, Primitive::Triangles));
-        // vao.add_vb(VertexBuffer::create(&plane.texcoords, 2, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&plane.vertices, 3));
+        vao.add_vb(VertexBuffer::create(&plane.normals, 3));
         vao.add_ib(IndexBuffer::create(&plane.indices)?);
 
         Ok(Mesh {

--- a/src/mesh/screen_rect.rs
+++ b/src/mesh/screen_rect.rs
@@ -78,10 +78,10 @@ fn create_texcoords() -> Vec<f32> {
 
 impl ScreenRect {
     pub fn new() -> Result<Self, RenderError> {
-        let mut vao = VertexArrayObject::new()?;
+        let mut vao = VertexArrayObject::new(Primitive::Triangles)?;
 
-        vao.add_vb(VertexBuffer::create(&create_vertices(), 2, Primitive::Triangles));
-        vao.add_vb(VertexBuffer::create(&create_texcoords(), 2, Primitive::Triangles));
+        vao.add_vb(VertexBuffer::create(&create_vertices(), 2));
+        vao.add_vb(VertexBuffer::create(&create_texcoords(), 2));
 
         let program = create_program()?;
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -4,11 +4,14 @@ use gl;
 
 use render::{IndexBuffer, RenderError, VertexBuffer};
 use render::traits::{Bindable, Drawable};
+use super::Primitive;
 
 /// A struct to represent a OpenGL vertex array object (VAO)
 pub struct VertexArrayObject {
     /// the OpenGL instance id
     id: u32,
+    /// The used render type
+    primitive_type: Primitive,
     /// The list of Vertex Buffers
     vbs: Vec<VertexBuffer>,
     /// The list of Index Buffers,
@@ -17,7 +20,7 @@ pub struct VertexArrayObject {
 
 impl VertexArrayObject {
     /// Create a new instance of a VertexArrayObject
-    pub fn new() -> Result<VertexArrayObject, RenderError> {
+    pub fn new(primitive_type: Primitive) -> Result<VertexArrayObject, RenderError> {
         let mut id = 0;
 
         unsafe {
@@ -26,6 +29,7 @@ impl VertexArrayObject {
 
         Ok(VertexArrayObject {
             id,
+            primitive_type,
             vbs: vec![],
             ibs: vec![],
         })
@@ -108,7 +112,7 @@ impl Drawable for VertexArrayObject {
         let vb = &self.vbs[0];
         if self.ibs.is_empty() {
             unsafe {
-                gl::DrawArrays(vb.render_type.into(), 0, vb.size() as i32);
+                gl::DrawArrays(self.primitive_type.into(), 0, vb.size() as i32);
             }
         } else {
             let ib = &self.ibs[0];

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -58,7 +58,7 @@ impl Bindable for VertexArrayObject {
                 gl::VertexAttribPointer(
                     i as u32,
                     vb.num_components(),
-                    gl::FLOAT,
+                    vb.gl_type().into(),
                     gl::FALSE,
                     stride,
                     ptr::null(),

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -3,13 +3,49 @@ use std::mem;
 use gl;
 use gl::types::*;
 
-use render::*;
-use render::traits::{Bindable};
+use render::Primitive;
+use render::traits::Bindable;
+
+#[derive(Debug)]
+#[repr(u32)]
+pub enum VertexType {
+    Byte,
+    UnsignedByte,
+    Short,
+    UnsignedShort,
+    Int,
+    UnsignedInt,
+    Float,
+    HalfFloat,
+    Double,
+    Fixed,
+}
+
+impl From<VertexType> for gl::types::GLenum {
+    fn from(vertex_type: VertexType) -> Self {
+        match vertex_type {
+            VertexType::Byte => gl::BYTE,
+            VertexType::UnsignedByte => gl::UNSIGNED_BYTE,
+            VertexType::Short => gl::SHORT,
+            VertexType::UnsignedShort => gl::UNSIGNED_SHORT,
+            VertexType::Int => gl::INT,
+            VertexType::UnsignedInt => gl::UNSIGNED_INT,
+            VertexType::Float => gl::FLOAT,
+            VertexType::HalfFloat => gl::HALF_FLOAT,
+            VertexType::Double => gl::DOUBLE,
+            VertexType::Fixed => gl::FIXED,
+        }
+    }
+}
 
 pub struct VertexBuffer {
+    /// Id reference to Open GL allocated buffer
     pub id: u32,
+    /// Number of vertex data
     pub count: usize,
+    /// Number of components per vertex
     num_components: i32,
+    // TODO maybe remove from here?
     pub render_type: Primitive,
 }
 
@@ -46,6 +82,10 @@ impl VertexBuffer {
 
     pub fn num_components(&self) -> i32 {
         self.num_components
+    }
+
+    pub fn gl_type(&self) -> VertexType {
+        VertexType::Float
     }
 
     pub fn component_size(&self) -> i32 {

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -45,12 +45,10 @@ pub struct VertexBuffer {
     pub count: usize,
     /// Number of components per vertex
     num_components: i32,
-    // TODO maybe remove from here?
-    pub render_type: Primitive,
 }
 
 impl VertexBuffer {
-    pub fn create(vertex_data: &[f32], num_components: u32, render_type: Primitive) -> VertexBuffer {
+    pub fn create(vertex_data: &[f32], num_components: u32) -> VertexBuffer {
         let total_size = vertex_data.len() * mem::size_of::<GLfloat>();
 
         let mut id = 0;
@@ -72,7 +70,6 @@ impl VertexBuffer {
             id,
             count: vertex_data.len() / (num_components as usize),
             num_components: num_components as i32,
-            render_type,
         }
     }
 
@@ -90,10 +87,6 @@ impl VertexBuffer {
 
     pub fn component_size(&self) -> i32 {
         self.num_components * 4
-    }
-
-    pub fn gl_primitive(&self) -> u32 {
-        self.render_type.into()
     }
 }
 


### PR DESCRIPTION
Add `VertexType` enum to reflect all possible GL enum values to use in function [glVertexAttribPointer](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glVertexAttribPointer.xhtml).

* refactor declaration of `PrimitiveType`, moved to `VertexArrayObject`, previously it was possible to declare multiple vertex buffers with different render primitive