### PR TITLE
Extend enums Primitive and Capability

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -111,6 +111,10 @@ impl Point2<u32> {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 pub enum Primitive {
+    /// used to render lines
+    Lines = gl::LINES,
+    /// used to render points
+    Points = gl::POINTS,
     /// used to render separate triangles
     Triangles = gl::TRIANGLES,
     /// used to render connected triangle strips
@@ -120,6 +124,8 @@ pub enum Primitive {
 impl From<Primitive> for gl::types::GLenum {
     fn from(primitive: Primitive) -> Self {
         match primitive {
+            Primitive::Lines => gl::LINES,
+            Primitive::Points => gl::POINTS,
             Primitive::Triangles => gl::TRIANGLES,
             Primitive::TriangleStrip => gl::TRIANGLE_STRIP,
         }
@@ -195,10 +201,12 @@ impl From<PixelType> for gl::types::GLenum {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u32)]
 pub enum Capability {
-    /// enable or disable depth tests
+    /// Enable or disable depth tests
     DepthTest = gl::DEPTH_TEST,
-    /// back side culling faces / polygons
+    /// Back side culling faces / polygons
     CullFace = gl::CULL_FACE,
+    /// Enables to set gl_PointSize in shader
+    ProgramPointSize = gl::PROGRAM_POINT_SIZE,
 }
 
 impl From<gl::types::GLenum> for Capability {
@@ -206,6 +214,7 @@ impl From<gl::types::GLenum> for Capability {
         match value {
             gl::DEPTH_TEST => Capability::DepthTest,
             gl::CULL_FACE => Capability::CullFace,
+            gl::PROGRAM_POINT_SIZE => Capability::ProgramPointSize,
             _ => panic!("Unknown capability found: {}", value),
         }
     }
@@ -216,6 +225,7 @@ impl From<Capability> for gl::types::GLenum {
         match cap {
             Capability::DepthTest => gl::DEPTH_TEST,
             Capability::CullFace => gl::CULL_FACE,
+            Capability::ProgramPointSize => gl::PROGRAM_POINT_SIZE,
         }
     }
 }

--- a/src/render/shader.rs
+++ b/src/render/shader.rs
@@ -157,6 +157,16 @@ impl Shader {
         Shader::create(&source, shader_type)
     }
 
+    /// Creates a new vertex shader
+    pub fn create_vertex(source: &str) -> Result<Self, ShaderError> {
+        Shader::create(source, ShaderType::Vertex)
+    }
+
+    /// Creates a new fragment shader
+    pub fn create_fragment(source: &str) -> Result<Self, ShaderError> {
+        Shader::create(source, ShaderType::Fragment)
+    }
+
     /// Creates and compiles a shader from source
     pub fn create(source: &str, shader_type: ShaderType) -> Result<Self, ShaderError> {
         compile_shader(source, &shader_type).map(|id| Shader{ id, source: source.into(), shader_type} )


### PR DESCRIPTION
This PR extends both enums `Primitive` and `Capability` with values.

* add constructor functions to Shader