### PR TITLE
Add basic Canvas functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ name = "spotlight"
 path = "examples/04-spotlight/main.rs"
 
 [[example]]
+name = "marching-cubes"
+path = "examples/05-marching-cubes/main.rs"
+
+[[example]]
 name = "filewatch"
 
 [dependencies]

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -5,28 +5,23 @@
 extern crate gl;
 extern crate noire;
 extern crate notify;
+extern crate rand;
 
 use gl::types::*;
 
 use noire::canvas::Canvas2D;
 use noire::math::Rect;
 use noire::render::{OpenGLWindow, RenderWindow, Size, Window};
+use rand::prelude::*;
 use std::time::{Duration, Instant};
-
-fn framebuffer_resized(width: u32, height: u32) {
-    println!("Framebuffer resized: {}x{}", width, height);
-}
 
 fn main() {
     let window_size = Size::new(1000, 600);
     let mut window = RenderWindow::create(&window_size, "Hello This is window")
         .expect("Failed to create Render Window");
 
-    window.framebuffer_resize_callback(framebuffer_resized);
-
-    println!("Window size: {:?}", window.get_size());
-
     let mut canvas = Canvas2D::new();
+    let mut rng = rand::thread_rng();
 
     let start_time = Instant::now();
 
@@ -35,12 +30,15 @@ fn main() {
         let elapsed = now.duration_since(start_time);
         let elapsed = (elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 * 1e-9) as f32;
 
+        let window_size = window.get_size();
+        let framebuffer_size = window.get_framebuffer_size();
+
+        window.reset_viewport();
         window.clear(0.3, 0.3, 0.3, 1.0);
 
-        canvas.clear(0.0, 0.0, 0.0, 0.0);
         canvas.draw_line(0, 0, 300, 300);
-        canvas.draw_line(100, 200, 240, 300);
-        canvas.render(&window.get_framebuffer_size());
+
+        canvas.render(&framebuffer_size);
 
         window.swap_buffers();
 

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -5,14 +5,12 @@
 extern crate gl;
 extern crate noire;
 extern crate notify;
-extern crate rand;
 
 use gl::types::*;
 
 use noire::canvas::Canvas2D;
-use noire::math::Rect;
+use noire::math::{Color, Rect};
 use noire::render::{OpenGLWindow, RenderWindow, Size, Window};
-use rand::prelude::*;
 use std::time::{Duration, Instant};
 
 fn main() {
@@ -21,7 +19,6 @@ fn main() {
         .expect("Failed to create Render Window");
 
     let mut canvas = Canvas2D::new();
-    let mut rng = rand::thread_rng();
 
     let start_time = Instant::now();
 
@@ -36,6 +33,7 @@ fn main() {
         window.reset_viewport();
         window.clear(0.3, 0.3, 0.3, 1.0);
 
+        canvas.set_color(Color::new(0.0, 1.0, 0.0, 1.0));
         canvas.draw_line(0, 0, 300, 300);
 
         canvas.render(&framebuffer_size);

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -10,13 +10,15 @@ use gl::types::*;
 
 use noire::canvas::Canvas2D;
 use noire::math::{Color, Rect};
-use noire::render::{OpenGLWindow, RenderWindow, Size, Window};
+use noire::render::{OpenGLWindow, RenderWindow, Size, Window, Capability};
 use std::time::{Duration, Instant};
 
 fn main() {
     let window_size = Size::new(1000, 600);
     let mut window = RenderWindow::create(&window_size, "Hello This is window")
         .expect("Failed to create Render Window");
+
+    window.enable(Capability::ProgramPointSize);
 
     let mut canvas = Canvas2D::new();
 
@@ -42,6 +44,11 @@ fn main() {
         canvas.set_color(Color::rgb(0.0, 1.0, 0.2));
         canvas.draw_rect(100, 350, 200, 500);
         canvas.draw_rect(250, 400, 350, 550);
+
+        canvas.set_color(Color::rgb(1.0, 1.0, 0.0));
+        canvas.set_pointsize(5.0);
+        canvas.draw_point(400, 250);
+        canvas.draw_point(400, 300);
 
         canvas.render(&framebuffer_size);
 

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -39,6 +39,10 @@ fn main() {
         canvas.draw_line(0, 100, 400, 400);
         canvas.draw_line(0, 150, 450, 450);
 
+        canvas.set_color(Color::rgb(0.0, 1.0, 0.2));
+        canvas.draw_rect(100, 350, 200, 500);
+        canvas.draw_rect(250, 400, 350, 550);
+
         canvas.render(&framebuffer_size);
 
         window.swap_buffers();

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
+extern crate gl;
+extern crate noire;
+extern crate notify;
+
+use gl::types::*;
+
+use noire::canvas::Canvas2D;
+use noire::math::Rect;
+use noire::render::{OpenGLWindow, RenderWindow, Size, Window};
+use std::time::{Duration, Instant};
+
+fn main() {
+    let window_size = Size::new(600, 600);
+    let mut window = RenderWindow::create(&window_size, "Hello This is window")
+        .expect("Failed to create Render Window");
+
+    let mut canvas = Canvas2D::new();
+
+    let start_time = Instant::now();
+
+    loop {
+        let now = Instant::now();
+        let elapsed = now.duration_since(start_time);
+        let elapsed = (elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 * 1e-9) as f32;
+
+        window.clear(0.3, 0.3, 0.3, 1.0);
+
+        canvas.clear(0.0, 0.0, 0.0, 0.0);
+
+        canvas.draw_rect(&Rect::new(0, 0, 100, 100));
+
+        canvas.render();
+        window.swap_buffers();
+
+        window.poll_events();
+        if window.should_close() {
+            return;
+        }
+    }
+}

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -13,10 +13,18 @@ use noire::math::Rect;
 use noire::render::{OpenGLWindow, RenderWindow, Size, Window};
 use std::time::{Duration, Instant};
 
+fn framebuffer_resized(width: u32, height: u32) {
+    println!("Framebuffer resized: {}x{}", width, height);
+}
+
 fn main() {
-    let window_size = Size::new(600, 600);
+    let window_size = Size::new(1000, 600);
     let mut window = RenderWindow::create(&window_size, "Hello This is window")
         .expect("Failed to create Render Window");
+
+    window.framebuffer_resize_callback(framebuffer_resized);
+
+    println!("Window size: {:?}", window.get_size());
 
     let mut canvas = Canvas2D::new();
 
@@ -30,8 +38,9 @@ fn main() {
         window.clear(0.3, 0.3, 0.3, 1.0);
 
         canvas.clear(0.0, 0.0, 0.0, 0.0);
-        canvas.draw_line(0, 0, 1, 1);
-        canvas.render(&window.get_size());
+        canvas.draw_line(0, 0, 300, 300);
+        canvas.draw_line(100, 200, 240, 300);
+        canvas.render(&window.get_framebuffer_size());
 
         window.swap_buffers();
 

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -30,8 +30,8 @@ fn main() {
         window.clear(0.3, 0.3, 0.3, 1.0);
 
         canvas.clear(0.0, 0.0, 0.0, 0.0);
-        canvas.draw_line(0, 0, 50, 50);
-        canvas.render();
+        canvas.draw_line(0, 0, 1, 1);
+        canvas.render(&window.get_size());
 
         window.swap_buffers();
 

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -33,8 +33,11 @@ fn main() {
         window.reset_viewport();
         window.clear(0.3, 0.3, 0.3, 1.0);
 
-        canvas.set_color(Color::new(0.0, 1.0, 0.0, 1.0));
+        canvas.set_color(Color::rgb(1.0, 0.0, 0.0));
         canvas.draw_line(0, 0, 300, 300);
+        canvas.draw_line(0, 50, 350, 350);
+        canvas.draw_line(0, 100, 400, 400);
+        canvas.draw_line(0, 150, 450, 450);
 
         canvas.render(&framebuffer_size);
 

--- a/examples/05-marching-cubes/main.rs
+++ b/examples/05-marching-cubes/main.rs
@@ -30,10 +30,9 @@ fn main() {
         window.clear(0.3, 0.3, 0.3, 1.0);
 
         canvas.clear(0.0, 0.0, 0.0, 0.0);
-
-        canvas.draw_rect(&Rect::new(0, 0, 100, 100));
-
+        canvas.draw_line(0, 0, 50, 50);
         canvas.render();
+
         window.swap_buffers();
 
         window.poll_events();

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -86,14 +86,10 @@ impl Canvas2D {
         let mut lines = self.line_vertices.borrow_mut();
         lines.push(start_x as f32);
         lines.push(start_y as f32);
-        lines.push(self.draw_color.red);
-        lines.push(self.draw_color.green);
-        lines.push(self.draw_color.blue);
+        lines.append(&mut self.draw_color.rgb_vec());
         lines.push(end_x as f32);
         lines.push(end_y as f32);
-        lines.push(self.draw_color.red);
-        lines.push(self.draw_color.green);
-        lines.push(self.draw_color.blue);
+        lines.append(&mut self.draw_color.rgb_vec());
         self
     }
 
@@ -102,34 +98,22 @@ impl Canvas2D {
         let mut rects = self.rect_vertices.borrow_mut();
         rects.push(left as f32);
         rects.push(top as f32);
-        rects.push(self.draw_color.red);
-        rects.push(self.draw_color.green);
-        rects.push(self.draw_color.blue);
+        rects.append(&mut self.draw_color.rgb_vec());
         rects.push(right as f32);
         rects.push(top as f32);
-        rects.push(self.draw_color.red);
-        rects.push(self.draw_color.green);
-        rects.push(self.draw_color.blue);
+        rects.append(&mut self.draw_color.rgb_vec());
         rects.push(right as f32);
         rects.push(bottom as f32);
-        rects.push(self.draw_color.red);
-        rects.push(self.draw_color.green);
-        rects.push(self.draw_color.blue);
+        rects.append(&mut self.draw_color.rgb_vec());
         rects.push(right as f32);
         rects.push(bottom as f32);
-        rects.push(self.draw_color.red);
-        rects.push(self.draw_color.green);
-        rects.push(self.draw_color.blue);
+        rects.append(&mut self.draw_color.rgb_vec());
         rects.push(left as f32);
         rects.push(bottom as f32);
-        rects.push(self.draw_color.red);
-        rects.push(self.draw_color.green);
-        rects.push(self.draw_color.blue);
+        rects.append(&mut self.draw_color.rgb_vec());
         rects.push(left as f32);
         rects.push(top as f32);
-        rects.push(self.draw_color.red);
-        rects.push(self.draw_color.green);
-        rects.push(self.draw_color.blue);
+        rects.append(&mut self.draw_color.rgb_vec());
         self
     }
 

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -110,9 +110,9 @@ impl Canvas2D {
 
         if !lines.is_empty() {
             // create buffers
-            let vb = VertexBuffer::create(&lines[..], 2, Primitive::Lines);
-            let vb_colors = VertexBuffer::create(&colors[..], 3, Primitive::Lines);
-            let mut vao = VertexArrayObject::new().unwrap();
+            let vb = VertexBuffer::create(&lines[..], 2);
+            let vb_colors = VertexBuffer::create(&colors[..], 3);
+            let mut vao = VertexArrayObject::new(Primitive::Lines).unwrap();
             vao.add_vb(vb);
             vao.add_vb(vb_colors);
 

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -12,7 +12,12 @@ uniform vec2 u_resolution;
 in vec2 position;
 
 void main() {
-    gl_Position = vec4(position, 0.0, 1.0);
+    float aspect_x = u_resolution.y / u_resolution.x;
+    float aspect_y = 1.0 / aspect_x;
+    float x = (-1.0) + position.x / (u_resolution.y / 2.0) * aspect_x;
+    float y = (-1.0) + position.y / (u_resolution.x / 2.0) * aspect_y;
+
+    gl_Position = vec4(x, y, 0.0, 1.0);
 }
 "#;
 
@@ -87,7 +92,7 @@ impl Canvas2D {
     }
 
     /// Renders the content of the canvas.
-    pub fn render(&mut self, screen_size: &Size<u32>) {
+    pub fn render(&mut self, size: &Size<u32>) {
         let lines = self.line_vertices.borrow();
 
         if !lines.is_empty() {
@@ -98,7 +103,7 @@ impl Canvas2D {
 
             // bind resources, uniforms, attributes
             self.program.bind();
-            self.program.uniform("u_size", Uniform::Float2(screen_size.width as f32, screen_size.height as f32));
+            self.program.uniform("u_resolution", Uniform::Float2(size.width as f32, size.height as f32));
 
             vao.bind();
             vao.draw();

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, cell::RefCell};
+use std::cell::RefCell;
 
 use math::{Color, Rect};
 use render::{Primitive, Program, Shader, VertexArrayObject, VertexBuffer};
@@ -12,10 +12,8 @@ uniform vec2 u_resolution;
 in vec2 position;
 
 void main() {
-    float aspect_x = u_resolution.y / u_resolution.x;
-    float aspect_y = 1.0 / aspect_x;
-    float x = (-1.0) + position.x / (u_resolution.y / 2.0) * aspect_x;
-    float y = (-1.0) + position.y / (u_resolution.x / 2.0) * aspect_y;
+    float x = (-1.0) + 2.0 * (position.x / u_resolution.x);
+    float y = (-1.0) + 2.0 * (position.y / u_resolution.y);
 
     gl_Position = vec4(x, y, 0.0, 1.0);
 }
@@ -62,7 +60,7 @@ impl Canvas2D {
     }
 
     /// Clears the canvas, sets it to given colors
-    pub fn clear(&self, r: f32, g: f32, b: f32, a: f32) -> &Self {
+    pub fn clear(&self, _r: f32, _g: f32, _b: f32, _a: f32) -> &Self {
         self
     }
 
@@ -93,7 +91,7 @@ impl Canvas2D {
 
     /// Renders the content of the canvas.
     pub fn render(&mut self, size: &Size<u32>) {
-        let lines = self.line_vertices.borrow();
+        let mut lines = self.line_vertices.borrow_mut();
 
         if !lines.is_empty() {
             // create buffers
@@ -111,6 +109,8 @@ impl Canvas2D {
 
             // unbind resources
             self.program.unbind();
+
+            lines.clear();
         }
     }
 }

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -1,11 +1,13 @@
-use std::cell::RefCell;
+use std::{rc::Rc, cell::RefCell};
 
-use math::{Color, Rect, Vector2};
+use math::{Color, Rect};
 use render::{Primitive, Program, Shader, VertexArrayObject, VertexBuffer};
-use crate::render::{Bindable, Drawable};
+use crate::render::{Bindable, Drawable, Size, Uniform};
 
 static VERTEX_SHADER: &str = r#"
 #version 330
+
+uniform vec2 u_resolution;
 
 in vec2 position;
 
@@ -85,7 +87,7 @@ impl Canvas2D {
     }
 
     /// Renders the content of the canvas.
-    pub fn render(&mut self) {
+    pub fn render(&mut self, screen_size: &Size<u32>) {
         let lines = self.line_vertices.borrow();
 
         if !lines.is_empty() {
@@ -96,6 +98,7 @@ impl Canvas2D {
 
             // bind resources, uniforms, attributes
             self.program.bind();
+            self.program.uniform("u_size", Uniform::Float2(screen_size.width as f32, screen_size.height as f32));
 
             vao.bind();
             vao.draw();

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -1,15 +1,48 @@
-use math::{Color, Rect};
+use std::cell::RefCell;
+
+use math::{Color, Rect, Vector2};
+use render::{Program, Shader};
+
+static VERTEX_SHADER: &str = r#"
+#version 330
+
+void main() {
+    gl_Position = vec4(0.0, 0.0, 0.0, 0.1);
+}
+"#;
+
+static FRAGMENT_SHADER: &str = r#"
+#version 330
+
+in vec4 in_color;
+out vec4 out_color;
+
+void main() {
+    out_color = in_color;
+}
+"#;
 
 pub struct Canvas2D {
+    /// compiled shader program to render primitives
+    program: Program,
     /// color to render the next primitive with
     draw_color: Color,
+    /// store all line coordinates
+    line_vertices: RefCell<Box<Vec<Vector2<f32>>>>,
 }
 
 impl Canvas2D {
     /// Create a new instance of the canvas
     pub fn new() -> Self {
+        let vertex_shader = Shader::create_vertex(&VERTEX_SHADER).unwrap();
+        let fragment_shader = Shader::create_fragment(&FRAGMENT_SHADER).unwrap();
+
+        let program = Program::create(vertex_shader, fragment_shader).unwrap();
+
         Canvas2D {
+            program,
             draw_color: Color::BLACK,
+            line_vertices: RefCell::new(Box::new(Vec::new())),
         }
     }
 
@@ -23,8 +56,16 @@ impl Canvas2D {
         self
     }
 
-    /// Draws a single point
-    pub fn draw_point(&self) -> &Self {
+    /// Draws a point
+    pub fn draw_point(&self, x: f32, y: f32) -> &Self {
+        self
+    }
+
+    /// Draws a line
+    pub fn draw_line(&self, start_x: f32, start_y: f32, end_x: f32, end_y: f32) -> &Self {
+        let mut lines = self.line_vertices.borrow_mut();
+        lines.push(Vector2::<f32>{ x: start_x, y: start_y });
+        lines.push(Vector2::<f32>{ x: end_x, y: end_y });
         self
     }
 
@@ -35,6 +76,6 @@ impl Canvas2D {
 
     /// Renders the content of the canvas.
     pub fn render(&self) {
-        // TODO
+        let mut lines = self.line_vertices.borrow_mut();
     }
 }

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -1,0 +1,40 @@
+use math::{Color, Rect};
+
+pub struct Canvas2D {
+    /// color to render the next primitive with
+    draw_color: Color,
+}
+
+impl Canvas2D {
+    /// Create a new instance of the canvas
+    pub fn new() -> Self {
+        Canvas2D {
+            draw_color: Color::BLACK,
+        }
+    }
+
+    /// Clears the canvas, sets it to given colors
+    pub fn clear(&self, r: f32, g: f32, b: f32, a: f32) -> &Self {
+        self
+    }
+
+    pub fn set_color(&mut self, color: Color) -> &Self {
+        self.draw_color = color;
+        self
+    }
+
+    /// Draws a single point
+    pub fn draw_point(&self) -> &Self {
+        self
+    }
+
+    /// Draw a rect
+    pub fn draw_rect(&self, rect: &Rect) -> &Self {
+        self
+    }
+
+    /// Renders the content of the canvas.
+    pub fn render(&self) {
+        // TODO
+    }
+}

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use math::{Color, Rect};
 use render::{Primitive, Program, Shader, VertexArrayObject, VertexBuffer};
-use crate::render::{Bindable, Drawable, Size, Uniform};
+use crate::render::{Bindable, Drawable, Size, Uniform, vertex_buffer::{VertexType, VertexData}};
 
 static VERTEX_SHADER: &str = r#"
 #version 330

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -99,7 +99,7 @@ impl Canvas2D {
     }
 
     /// Draw a rect
-    pub fn draw_rect(&self, rect: &Rect) -> &Self {
+    pub fn draw_rect(&self, _rect: &Rect) -> &Self {
         self
     }
 

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -1,0 +1,3 @@
+pub use self::canvas::Canvas2D;
+
+pub mod canvas;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate glfw;
 extern crate notify;
 extern crate regex;
 
+pub mod canvas;
 pub mod input;
 pub mod math;
 pub mod mesh;

--- a/src/math/camera.rs
+++ b/src/math/camera.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, EuclideanSpace, Euler, InnerSpace, Matrix4, PerspectiveFov, Point3, Rad,
+use cgmath::{Deg, EuclideanSpace, Euler, InnerSpace, Matrix4, PerspectiveFov, Point3,
              Rotation, SquareMatrix, Vector3, Quaternion};
 use cgmath::vec3;
 use cgmath::One;

--- a/src/math/camera.rs
+++ b/src/math/camera.rs
@@ -46,9 +46,8 @@ impl Camera {
         self.aspect = aspect;
         self.znear = znear;
         self.zfar = zfar;
-        // self.projection = perspective(Rad::from(Deg(fov)), aspect, znear, zfar);
         self.projection = Matrix4::from(PerspectiveFov {
-            fovy: Rad::from(Deg(fov)),
+            fovy: Deg(fov).into(),
             aspect,
             near: znear,
             far: zfar,

--- a/src/math/color.rs
+++ b/src/math/color.rs
@@ -44,6 +44,11 @@ impl Color {
         [self.red, self.green, self.blue, self.alpha]
     }
 
+    /// Returns the rgb values as vec
+    pub fn rgb_vec(&self) -> Vec<f32> {
+        vec![self.red, self.green, self.blue]
+    }
+
     /// Returns color as array with RGB components
     pub fn rgb_array(&self) -> [f32; 3] {
         [self.red, self.green, self.blue]

--- a/src/math/color.rs
+++ b/src/math/color.rs
@@ -39,7 +39,13 @@ impl Color {
         }
     }
 
-    pub fn values(&self) -> [f32; 4] {
+    /// Returns color as array with RGBA components
+    pub fn rgba_array(&self) -> [f32; 4] {
         [self.red, self.green, self.blue, self.alpha]
+    }
+
+    /// Returns color as array with RGB components
+    pub fn rgb_array(&self) -> [f32; 3] {
+        [self.red, self.green, self.blue]
     }
 }

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -3,10 +3,12 @@
 pub use self::camera::Camera;
 pub use self::color::Color;
 pub use self::rect::Rect;
+pub use self::vector2::Vector2;
 
 pub mod camera;
 pub mod color;
 pub mod rect;
+pub mod vector2;
 
 use cgmath::{Matrix, Matrix3, Matrix4, Point3, Quaternion, SquareMatrix};
 

--- a/src/math/vector2.rs
+++ b/src/math/vector2.rs
@@ -1,0 +1,6 @@
+pub type Point2<T> = Vector2<T>;
+
+pub struct Vector2<T> {
+    pub x: T,
+    pub y: T,
+}

--- a/src/render/capabilities.rs
+++ b/src/render/capabilities.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::{string::FromUtf8Error, fmt::Display};
 
 use gl;
+use super::Size;
 
 #[derive(Debug)]
 pub struct CapabilityError {
@@ -45,12 +46,21 @@ pub struct Capabilities {
     pub debug: bool,
     /// When true the Context can be in Forward Compatible mode
     pub forward_compatible: bool,
+    /// Maximum texture size
+    pub max_texture_size: Size<usize>,
 }
 
 /// Fetches the Vendor string from OpenGL
 unsafe fn get_vendor() -> Result<String, CapabilityError> {
     let s = gl::GetString(gl::VENDOR);
     Ok(String::from_utf8(CStr::from_ptr(s as *const _).to_bytes().to_vec())?)
+}
+
+/// Fetches the max texture size from OpenGL
+unsafe fn get_max_texture_size() -> Size<usize> {
+    let mut size = 0;
+    gl::GetIntegerv(gl::MAX_TEXTURE_SIZE, &mut size);
+    Size::new(size as usize, size as usize)
 }
 
 /// Fetches the Renderer String from OpenGL
@@ -89,6 +99,7 @@ impl Capabilities {
         let version = unsafe { get_version()? };
         let shader_version = unsafe { get_shader_version()? };
         let (debug, forward_compatible) = unsafe { get_context_flags() };
+        let max_texture_size = unsafe { get_max_texture_size() };
 
         Ok(Capabilities {
             vendor,
@@ -97,6 +108,7 @@ impl Capabilities {
             shader_version,
             debug,
             forward_compatible,
+            max_texture_size,
         })
     }
 }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -50,6 +50,10 @@ impl VertexArrayObject {
 
 impl Bindable for VertexArrayObject {
     /// Binds the resource
+    ///
+    /// References
+    /// * https://stackoverflow.com/questions/16380005/opengl-3-4-glvertexattribpointer-stride-and-offset-miscalculation
+    /// * https://learnopengl.com/Getting-started/Shaders
     fn bind(&mut self) -> &mut Self {
         unsafe {
             gl::BindVertexArray(self.id);

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -64,9 +64,9 @@ impl Bindable for VertexArrayObject {
                     gl::VertexAttribPointer(
                         index as u32,
                         num_components as i32,
-                        vb.gl_type().into(),
+                        vb.vertex_type().into(),
                         gl::FALSE,
-                        0,
+                        vb.stride() as i32,
                         ptr::null(),
                     );
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -4,7 +4,7 @@ use gl;
 
 use render::{IndexBuffer, RenderError, VertexBuffer};
 use render::traits::{Bindable, Drawable};
-use super::{vertex_buffer::VertexTypeSize, Primitive};
+use super::Primitive;
 
 /// A struct to represent a OpenGL vertex array object (VAO)
 pub struct VertexArrayObject {

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -59,6 +59,7 @@ impl Bindable for VertexArrayObject {
         for vb in self.vbs.iter_mut() {
             vb.bind();
 
+            let mut offset = 0;
             for &num_components in &vb.components {
                 unsafe {
                     gl::VertexAttribPointer(
@@ -67,13 +68,14 @@ impl Bindable for VertexArrayObject {
                         vb.vertex_type().into(),
                         gl::FALSE,
                         vb.stride() as i32,
-                        ptr::null(),
+                        offset as *const gl::types::GLvoid,
                     );
 
                     gl::EnableVertexAttribArray(index as u32);
                 }
 
                 index += 1;
+                offset += num_components as usize * std::mem::size_of::<f32>();
             }
         }
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -64,22 +64,22 @@ impl Bindable for VertexArrayObject {
             vb.bind();
 
             let mut offset = 0;
-            for &num_components in &vb.components {
+            for &component in &vb.components {
                 unsafe {
                     gl::VertexAttribPointer(
                         index as u32,
-                        num_components as i32,
+                        component as i32,
                         vb.vertex_type().into(),
                         gl::FALSE,
                         vb.stride() as i32,
                         offset as *const gl::types::GLvoid,
                     );
 
-                    gl::EnableVertexAttribArray(index as u32);
+                    gl::EnableVertexAttribArray(index);
                 }
 
                 index += 1;
-                offset += num_components as usize * std::mem::size_of::<f32>();
+                offset += component as usize * std::mem::size_of::<f32>();
             }
         }
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -55,21 +55,20 @@ impl Bindable for VertexArrayObject {
             gl::BindVertexArray(self.id);
         }
 
-        let mut stride = 0;
-        for (i, vb) in self.vbs.iter_mut().enumerate() {
+        for (index, vb) in self.vbs.iter_mut().enumerate() {
             vb.bind();
+
             unsafe {
                 gl::VertexAttribPointer(
-                    i as u32,
+                    index as u32,
                     vb.num_components(),
                     vb.gl_type().into(),
                     gl::FALSE,
-                    stride,
+                    0,
                     ptr::null(),
                 );
-                gl::EnableVertexAttribArray(i as u32);
+                gl::EnableVertexAttribArray(index as u32);
             }
-            stride += vb.component_size();
         }
 
         for ib in self.ibs.iter_mut() {

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -109,6 +109,8 @@ impl Bindable for VertexArrayObject {
 impl Drawable for VertexArrayObject {
     /// Render the VertexArrayObject
     fn draw(&mut self) {
+        assert!(self.vbs.len() > 0);
+
         let vb = &self.vbs[0];
         if self.ibs.is_empty() {
             unsafe {

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -55,19 +55,27 @@ impl Bindable for VertexArrayObject {
             gl::BindVertexArray(self.id);
         }
 
-        for (index, vb) in self.vbs.iter_mut().enumerate() {
+        let mut index = 0;
+        for vb in self.vbs.iter_mut() {
             vb.bind();
 
-            unsafe {
-                gl::VertexAttribPointer(
-                    index as u32,
-                    vb.num_components(),
-                    vb.gl_type().into(),
-                    gl::FALSE,
-                    0,
-                    ptr::null(),
-                );
-                gl::EnableVertexAttribArray(index as u32);
+            let mut stride = 0;
+            for num_components in &vb.components {
+                unsafe {
+                    gl::VertexAttribPointer(
+                        index as u32,
+                        *num_components as i32,
+                        vb.gl_type().into(),
+                        gl::FALSE,
+                        0,
+                        ptr::null(),
+                    );
+
+                    gl::EnableVertexAttribArray(index as u32);
+                }
+
+                stride += num_components;
+                index += 1;
             }
         }
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -134,6 +134,7 @@ impl Drop for VertexArrayObject {
     fn drop(&mut self) {
         unsafe {
             gl::DeleteVertexArrays(1, &self.id);
+            self.id = 0;
         }
     }
 }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -4,7 +4,7 @@ use gl;
 
 use render::{IndexBuffer, RenderError, VertexBuffer};
 use render::traits::{Bindable, Drawable};
-use super::Primitive;
+use super::{vertex_buffer::VertexTypeSize, Primitive};
 
 /// A struct to represent a OpenGL vertex array object (VAO)
 pub struct VertexArrayObject {
@@ -59,12 +59,11 @@ impl Bindable for VertexArrayObject {
         for vb in self.vbs.iter_mut() {
             vb.bind();
 
-            let mut stride = 0;
-            for num_components in &vb.components {
+            for &num_components in &vb.components {
                 unsafe {
                     gl::VertexAttribPointer(
                         index as u32,
-                        *num_components as i32,
+                        num_components as i32,
                         vb.gl_type().into(),
                         gl::FALSE,
                         0,
@@ -74,7 +73,6 @@ impl Bindable for VertexArrayObject {
                     gl::EnableVertexAttribArray(index as u32);
                 }
 
-                stride += num_components;
                 index += 1;
             }
         }

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -5,7 +5,7 @@ use gl::types::*;
 
 use render::traits::Bindable;
 
-trait VertexTypeSize {
+pub trait VertexTypeSize {
     /// Returns the size of the vertex type in bytes
     fn size(&self) -> u32;
     /// Returns the Open GL enum value of the vertex type
@@ -68,6 +68,7 @@ impl VertexTypeSize for VertexType {
     }
 }
 
+#[derive(Debug)]
 pub struct VertexData<'a> {
     /// Holds the list of vertex data
     pub data: &'a [f32],
@@ -102,7 +103,7 @@ impl <'a> VertexData<'a> {
 pub struct VertexBuffer {
     /// Id reference to Open GL allocated buffer
     pub id: u32,
-    /// Number of vertices, e.g. (x,y,z,rg,b)
+    /// Number of vertices, e.g. [(x,y,z,rg,b), (), ...]
     pub count: usize,
     /// Number of components per vertex, e.g. (x,y,z),(r,g,b)
     pub components: Vec<u32>,
@@ -137,18 +138,18 @@ impl VertexBuffer {
         VertexBuffer {
             id,
             count: vertex_data.count(),
-            components: Vec::new(),
+            components: vertex_data.components.clone(),
             vertex_type: vertex_data.vertex_type,
         }
     }
 
     /// Creates a new VertexBuffer from a float array
-    pub fn create(vertex_data: &[f32], num_components: usize) -> Self {
-        let id = unsafe { generate_buffer(vertex_data) };
+    pub fn create(data: &[f32], num_components: usize) -> Self {
+        let id = unsafe { generate_buffer(data) };
 
         VertexBuffer {
             id,
-            count: vertex_data.len() / num_components,
+            count: data.len() / num_components,
             components: vec![num_components as u32],
             vertex_type: VertexType::Float,
         }
@@ -170,7 +171,7 @@ impl VertexBuffer {
         self.vertex_type
     }
 
-    /// Returns the size in bytes of all vertex components, e.g. (x,y,z,nx,ny) = 5
+    /// Returns the size in bytes of all vertex components, e.g. (x,y,z,nx,ny) = 5 * 4
     pub fn component_size(&self) -> i32 {
         (self.num_components() as usize * (mem::size_of::<f32>())) as i32
     }

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -49,7 +49,7 @@ pub struct VertexBuffer {
 
 impl VertexBuffer {
     pub fn create(vertex_data: &[f32], num_components: u32) -> VertexBuffer {
-        let total_size = vertex_data.len() * mem::size_of::<GLfloat>();
+        let total_size = vertex_data.len() * mem::size_of::<f32>();
 
         let mut id = 0;
 

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -27,9 +27,33 @@ pub enum VertexType {
     Fixed,
 }
 
-impl From<VertexType> for gl::types::GLenum {
+impl From<VertexType> for u32 {
     fn from(vertex_type: VertexType) -> Self {
-        match vertex_type {
+        vertex_type.gl_type()
+    }
+}
+
+impl VertexTypeSize for VertexType {
+    /// Returns the size of the data type, see
+    /// https://www.khronos.org/opengl/wiki/OpenGL_Type
+    fn size(&self) -> u32 {
+        match self {
+            VertexType::Byte => 1,
+            VertexType::UnsignedByte => 1,
+            VertexType::Short => 2,
+            VertexType::UnsignedShort => 2,
+            VertexType::Int => 4,
+            VertexType::UnsignedInt => 4,
+            VertexType::Float => 4,
+            VertexType::HalfFloat => 2,
+            VertexType::Double => 8,
+            VertexType::Fixed => 4,
+        }
+    }
+
+    /// Returns the Open GL enum type
+    fn gl_type(&self) -> u32 {
+        match self {
             VertexType::Byte => gl::BYTE,
             VertexType::UnsignedByte => gl::UNSIGNED_BYTE,
             VertexType::Short => gl::SHORT,
@@ -41,16 +65,6 @@ impl From<VertexType> for gl::types::GLenum {
             VertexType::Double => gl::DOUBLE,
             VertexType::Fixed => gl::FIXED,
         }
-    }
-}
-
-impl VertexTypeSize for VertexType {
-    fn size(&self) -> u32 {
-        todo!()
-    }
-
-    fn gl_type(&self) -> gl::types::GLenum {
-        todo!()
     }
 }
 
@@ -124,7 +138,7 @@ impl VertexBuffer {
         VertexBuffer {
             id,
             count: vertex_data.len() / (num_components as usize),
-            num_components: num_components,
+            num_components,
         }
     }
 

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -167,8 +167,13 @@ impl VertexBuffer {
         &self.components
     }
 
-    pub fn gl_type(&self) -> VertexType {
+    pub fn vertex_type(&self) -> VertexType {
         self.vertex_type
+    }
+
+    /// Returns the stride of full vertex, number of bytes of all components
+    pub fn stride(&self) -> u32 {
+        self.num_components() * self.vertex_type.size()
     }
 
     /// Returns the size in bytes of all vertex components, e.g. (x,y,z,nx,ny) = 5 * 4

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -3,7 +3,6 @@ use std::mem;
 use gl;
 use gl::types::*;
 
-use render::Primitive;
 use render::traits::Bindable;
 
 #[derive(Debug)]
@@ -38,6 +37,7 @@ impl From<VertexType> for gl::types::GLenum {
     }
 }
 
+#[derive(Debug)]
 pub struct VertexBuffer {
     /// Id reference to Open GL allocated buffer
     pub id: u32,
@@ -86,7 +86,7 @@ impl VertexBuffer {
     }
 
     pub fn component_size(&self) -> i32 {
-        self.num_components * 4
+        self.num_components * (mem::size_of::<f32>()) as i32
     }
 }
 

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -5,6 +5,13 @@ use gl::types::*;
 
 use render::traits::Bindable;
 
+trait VertexTypeSize {
+    /// Returns the size of the vertex type in bytes
+    fn size(&self) -> u32;
+    /// Returns the Open GL enum value of the vertex type
+    fn gl_type(&self) -> gl::types::GLenum;
+}
+
 #[derive(Debug)]
 #[repr(u32)]
 pub enum VertexType {
@@ -37,9 +44,13 @@ impl From<VertexType> for gl::types::GLenum {
     }
 }
 
-impl VertexType {
-    pub fn size(&self) -> u32 {
-        0
+impl VertexTypeSize for VertexType {
+    fn size(&self) -> u32 {
+        todo!()
+    }
+
+    fn gl_type(&self) -> gl::types::GLenum {
+        todo!()
     }
 }
 
@@ -60,6 +71,11 @@ impl <'a> VertexData<'a> {
             components: Vec::from(components),
         }
     }
+
+    /// Returns the number of different components
+    pub fn components_count(&self) -> usize {
+        self.components.len()
+    }
 }
 
 #[derive(Debug)]
@@ -69,7 +85,7 @@ pub struct VertexBuffer {
     /// Number of vertex data
     pub count: usize,
     /// Number of components per vertex
-    num_components: i32,
+    num_components: usize,
 }
 
 /// Generates a new Array Buffer and returns the associated id
@@ -97,18 +113,18 @@ impl VertexBuffer {
         VertexBuffer {
             id: 0,
             count: 0,
-            num_components: 0
+            num_components: vertex_data.components_count(),
         }
     }
 
     /// Creates a new VertexBuffer from a float array
-    pub fn create(vertex_data: &[f32], num_components: u32) -> Self {
+    pub fn create(vertex_data: &[f32], num_components: usize) -> Self {
         let id = unsafe { generate_buffer(vertex_data) };
 
         VertexBuffer {
             id,
             count: vertex_data.len() / (num_components as usize),
-            num_components: num_components as i32,
+            num_components: num_components,
         }
     }
 
@@ -117,7 +133,7 @@ impl VertexBuffer {
     }
 
     pub fn num_components(&self) -> i32 {
-        self.num_components
+        self.num_components as i32
     }
 
     pub fn gl_type(&self) -> VertexType {
@@ -125,7 +141,7 @@ impl VertexBuffer {
     }
 
     pub fn component_size(&self) -> i32 {
-        self.num_components * (mem::size_of::<f32>()) as i32
+        self.num_components() * (mem::size_of::<f32>()) as i32
     }
 }
 

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -217,6 +217,12 @@ impl RenderWindow {
         })
     }
 
+    /// Returns the current window size
+    pub fn get_size(&self) -> Size<u32> {
+        let (width, height) = self.window.get_size();
+        Size{ width: width as u32, height: height as u32 }
+    }
+
     pub fn aspect(&self) -> f32 {
         let (width, height) = self.window.get_size();
         width as f32 / height as f32


### PR DESCRIPTION
This PR adds a new example application to help build a 2D Canvas struct.

The new `Canvas2D` is meant to be used as a 2d canvas (think HTML5 Canvas) to draw primitives on, e.g. lines, points and rects. It's very basic but should be enough to get at least basic rendering going. It uses vectors of vertices that are put into VertexBuffer and VAO during rendering. It is not optimized for throughput.

It extends / fixes the VertexArrayObject render function to also support `VertexBuffer` with multiple vertex components, e.g. `x, y, z` & `r, g, b` in the same contiguous array of floats.
