### PR TITLE
Add vector2 and vector3 structs

### DIFF
--- a/examples/04-spotlight/main.rs
+++ b/examples/04-spotlight/main.rs
@@ -12,7 +12,7 @@ use std::time::{Instant};
 
 use noire::math::*;
 use noire::math::{Camera, Color};
-use noire::mesh::{Cube, Mesh, Node, Plane, Scene, ScreenRect};
+use noire::mesh::{Cube, Mesh, Node, Plane, Scene};
 use noire::render::{FrameBuffer, Program, Spotlight, Texture, Uniform};
 use noire::render::traits::*;
 use noire::render::{Capability, CullMode, Point2, Size};

--- a/src/math/vector2.rs
+++ b/src/math/vector2.rs
@@ -1,6 +1,54 @@
-pub type Point2<T> = Vector2<T>;
+use std::ops::Sub;
 
-pub struct Vector2<T> {
-    pub x: T,
-    pub y: T,
+#[derive(Copy, Clone)]
+pub struct Vector2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vector2 {
+    /// Construct a new vector
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    /// Calculate distance to another Vector
+    pub fn distance(self, rhs: Vector2) -> f32 {
+        (rhs - self).length()
+    }
+
+    /// Calculates the length of the Vector
+    pub fn length(&self) -> f32 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+}
+
+impl Sub for Vector2 {
+    type Output = Vector2;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Vector2 {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Vector2;
+
+    #[test]
+    fn it_returns_length() {
+        assert_eq!(Vector2::new(1.0, 0.0).length(), 1.0);
+        assert_eq!(Vector2::new(0.0, 5.0).length(), 5.0);
+        assert_eq!(Vector2::new(3.0, 4.0).length(), 5.0);
+    }
+
+    #[test]
+    fn it_calculates_distance() {
+        let v1 = Vector2::new(1.0, 1.0);
+        let v2 = Vector2::new(4.0, 5.0);
+        assert_eq!(v1.distance(v2), 5.0);
+    }
 }

--- a/src/math/vector3.rs
+++ b/src/math/vector3.rs
@@ -1,0 +1,56 @@
+use std::ops::Sub;
+
+pub type Point3 = Vector3;
+
+#[derive(Copy, Clone)]
+pub struct Vector3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl Vector3 {
+    /// Construct a new Vector3
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+
+    /// Calculate distance to another Vector3
+    pub fn distance(self, rhs: Vector3) -> f32 {
+        (rhs - self).length()
+    }
+
+    /// Calculates the length of the Vector3
+    pub fn length(&self) -> f32 {
+        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
+    }
+}
+
+impl Sub for Vector3 {
+    type Output = Vector3;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+            z: self.z - rhs.z,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Vector3;
+
+    #[test]
+    fn vector_returns_length() {
+        assert_eq!(Vector3::new(0.0, 3.0, 4.0).length(), 5.0);
+    }
+
+    #[test]
+    fn vector_calculates_distance() {
+        let v1 = Vector3::new(0.0, 1.0, 1.0);
+        let v2 = Vector3::new(3.0, 5.0, 1.0);
+        assert_eq!(v1.distance(v2), 5.0);
+    }
+}


### PR DESCRIPTION
This PR adds `Vector2` and `Vector3` structs, these implement a few basic functions.

This is mainly to get familiar with traits of module `std::ops::*`.