### PR TITLE
Change return type of VAO constructor

### DIFF
--- a/examples/02-triangles/main.rs
+++ b/examples/02-triangles/main.rs
@@ -31,7 +31,7 @@ fn main() {
     let vb = VertexBuffer::create(&VERTICES, 2);
     let ib = IndexBuffer::create(&INDICES).unwrap();
 
-    let mut vao = VertexArrayObject::new(Primitive::TriangleStrip).unwrap();
+    let mut vao = VertexArrayObject::new(Primitive::TriangleStrip);
     vao.add_vb(vb);
     vao.add_ib(ib);
 

--- a/examples/03-raymarching/main.rs
+++ b/examples/03-raymarching/main.rs
@@ -58,7 +58,7 @@ fn main() {
 
     // create vertex data
     let vb = VertexBuffer::create(&VERTICES, 2);
-    let mut vao = VertexArrayObject::new(Primitive::TriangleStrip).unwrap();
+    let mut vao = VertexArrayObject::new(Primitive::TriangleStrip);
     vao.add_vb(vb);
 
     let mut last_pos = Pos { x: 0, y: 0 };

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -152,7 +152,7 @@ impl Canvas2D {
             let vb = VertexBuffer::new(&vertex_data);
 
             // create buffers
-            let mut vao = VertexArrayObject::new(Primitive::Points).unwrap();
+            let mut vao = VertexArrayObject::new(Primitive::Points);
             vao.add_vb(vb);
 
             // bind resources, uniforms, attributes
@@ -180,7 +180,7 @@ impl Canvas2D {
             let vb = VertexBuffer::new(&vertex_data);
 
             // create buffers
-            let mut vao = VertexArrayObject::new(Primitive::Lines).unwrap();
+            let mut vao = VertexArrayObject::new(Primitive::Lines);
             vao.add_vb(vb);
 
             // bind resources, uniforms, attributes
@@ -207,7 +207,7 @@ impl Canvas2D {
             let vb = VertexBuffer::new(&vertex_data);
 
             // create buffers
-            let mut vao = VertexArrayObject::new(Primitive::Triangles).unwrap();
+            let mut vao = VertexArrayObject::new(Primitive::Triangles);
             vao.add_vb(vb);
 
             // bind resources, uniforms, attributes

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -16,7 +16,7 @@ pub struct Mesh {
 impl Mesh {
     /// Creates a Mesh object from a Cube
     pub fn create_cube(cube: Cube, color: Color) -> Result<Mesh, RenderError> {
-        let mut vao = VertexArrayObject::new(Primitive::Triangles)?;
+        let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
         vao.add_vb(VertexBuffer::create(&cube.vertices, 3));
         vao.add_vb(VertexBuffer::create(&cube.normals, 3));
@@ -30,7 +30,7 @@ impl Mesh {
 
     /// Creates a Mesh object from a Plane
     pub fn create_plane(plane: Plane, color: Color) -> Result<Mesh, RenderError> {
-        let mut vao = VertexArrayObject::new(Primitive::Triangles)?;
+        let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
         vao.add_vb(VertexBuffer::create(&plane.vertices, 3));
         vao.add_vb(VertexBuffer::create(&plane.normals, 3));

--- a/src/mesh/screen_rect.rs
+++ b/src/mesh/screen_rect.rs
@@ -78,7 +78,7 @@ fn create_texcoords() -> Vec<f32> {
 
 impl ScreenRect {
     pub fn new() -> Result<Self, RenderError> {
-        let mut vao = VertexArrayObject::new(Primitive::Triangles)?;
+        let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
         vao.add_vb(VertexBuffer::create(&create_vertices(), 2));
         vao.add_vb(VertexBuffer::create(&create_texcoords(), 2));

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -2,7 +2,7 @@ use std::ptr;
 
 use gl;
 
-use render::{IndexBuffer, RenderError, VertexBuffer};
+use render::{IndexBuffer, VertexBuffer};
 use render::traits::{Bindable, Drawable};
 use super::Primitive;
 
@@ -20,19 +20,19 @@ pub struct VertexArrayObject {
 
 impl VertexArrayObject {
     /// Create a new instance of a VertexArrayObject
-    pub fn new(primitive_type: Primitive) -> Result<VertexArrayObject, RenderError> {
+    pub fn new(primitive_type: Primitive) -> VertexArrayObject {
         let mut id = 0;
 
         unsafe {
             gl::GenVertexArrays(1, &mut id);
         }
 
-        Ok(VertexArrayObject {
+        VertexArrayObject {
             id,
             primitive_type,
             vbs: vec![],
             ibs: vec![],
-        })
+        }
     }
 
     /// Add a vertex buffer to use


### PR DESCRIPTION
Instead of returning a result, the VAO object is returned instead. The Result was not really used, there was no `Err` case.