### PR TITLE
Add RenderBuffer struct

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,6 +8,7 @@ pub use self::context::Context;
 pub use self::frame_buffer::FrameBuffer;
 pub use self::index_buffer::IndexBuffer;
 pub use self::program::{Program, ProgramError, Uniform};
+pub use self::render_buffer::RenderBuffer;
 pub use self::shader::{Shader, ShaderError, ShaderType};
 pub use self::spot_light::Spotlight;
 pub use self::texture::Texture;
@@ -22,6 +23,7 @@ pub mod frame_buffer;
 pub mod index_buffer;
 pub mod opengl;
 pub mod program;
+pub mod render_buffer;
 pub mod shader;
 pub mod texture;
 pub mod traits;
@@ -34,6 +36,14 @@ pub mod window;
 #[derive(Debug, Clone)]
 pub struct RenderError {
     pub message: String
+}
+
+impl RenderError {
+    pub fn new(message: String) -> Self {
+        Self {
+            message
+        }
+    }
 }
 
 /// Generates an appropriate error message for Display

--- a/src/render/opengl.rs
+++ b/src/render/opengl.rs
@@ -122,8 +122,8 @@ struct Frame {
 /// Fetches the last GL error, if present returns ERR, otherwise Ok
 /// The function also tries to find the source file location where the error originates from
 /// by traversing the back trace
-fn get_error<'a>() -> Result<(), String> {
-    let mut error = 0;
+pub(crate) fn get_error<'a>() -> Result<(), String> {
+    let error;
 
     unsafe {
         error = gl::GetError();

--- a/src/render/render_buffer.rs
+++ b/src/render/render_buffer.rs
@@ -1,0 +1,118 @@
+use super::{Format, Bindable, RenderError, opengl::get_error, Size};
+
+/// A RenderBuffer is a buffer meant for offscreen rendering.
+/// It is a storage object (buffer) containing a single image of a renderable format
+///
+pub struct RenderBuffer {
+    /// The associated OpenGL id (handle) to the RenderBuffer object
+    pub id: u32,
+    /// The color / pixel format
+    pub format: Format,
+    /// The MSAA sampling factor
+    pub msaa: u32,
+}
+
+impl RenderBuffer {
+    /// Creates a new RenderBuffer object.
+    /// It has not yet allocated any data storage.
+    pub fn new(format: Format, msaa: u32) -> Self {
+        let mut id = 0;
+
+        unsafe { gl::GenRenderbuffers(1, &mut id); }
+
+        Self {
+            id,
+            msaa,
+            format,
+        }
+    }
+
+    /// Allocate memory to hold 2 dimensional image / pixel data
+    ///
+    /// ## Useful resources:
+    /// * OpenGL Anti Aliasing https://learnopengl.com/Advanced-OpenGL/Anti-Aliasing
+    ///
+    pub fn allocate(&mut self, width: u32, height: u32) -> Result<(), RenderError> {
+        self.bind();
+
+        let msaa = 0;
+
+        unsafe {
+            gl::RenderbufferStorageMultisample(
+                gl::RENDERBUFFER,
+                msaa,
+                self.format.into(),
+                width as i32,
+                height as i32,
+            );
+        }
+
+        get_error().map_err(|message| RenderError::new(message))?;
+
+        self.unbind();
+
+        Ok(())
+    }
+
+    /// Returns the width of the Renderbuffer
+    pub fn width(&self) -> u32 {
+        let mut width = 0;
+
+        unsafe {
+            gl::GetRenderbufferParameteriv(gl::RENDERBUFFER, gl::RENDERBUFFER_WIDTH, &mut width);
+        }
+
+        width as u32
+    }
+
+    /// Returns the height of the Renderbuffer
+    pub fn height(&self) -> u32 {
+        let mut height = 0;
+
+        unsafe {
+            gl::GetRenderbufferParameteriv(gl::RENDERBUFFER, gl::RENDERBUFFER_HEIGHT, &mut height);
+        }
+
+        height as u32
+    }
+
+    /// Returns the dimensions of the Renderbuffer
+    pub fn size(&self) -> Size<u32> {
+        Size {
+            width: self.width(),
+            height: self.height(),
+        }
+    }
+}
+
+impl Bindable for RenderBuffer {
+    fn bind(&mut self) -> &mut Self {
+        unsafe {
+            gl::BindRenderbuffer(gl::RENDERBUFFER, self.id);
+        }
+        self
+    }
+
+    fn unbind(&mut self) -> &mut Self {
+        unsafe {
+            gl::BindRenderbuffer(gl::RENDERBUFFER, 0);
+        }
+        self
+    }
+
+    fn bound(&self) -> bool {
+        let mut id = 0;
+        unsafe {
+            gl::GetIntegerv(gl::RENDERBUFFER_BINDING, &mut id);
+        }
+        self.id == (id as u32)
+    }
+}
+
+impl Drop for RenderBuffer {
+    fn drop(&mut self) {
+        unsafe {
+            gl::DeleteRenderbuffers(1, &self.id);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a [Renderbuffer]() struct to render scenes to an offscreen buffer.

These resources are good starters to learn more about Renderbuffers:

* Introduction into Framebuffers: https://open.gl/framebuffers
* OpenGL Framebuffer: https://www.khronos.org/opengl/wiki/Framebuffer

The following changes were also done.

* refactor `get_error`, make it public to crate
* add constructor to `RenderError`