### PR TITLE
Add marching squares example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ name = "opensimplex"
 path = "examples/06-opensimplex/main.rs"
 
 [[example]]
+name = "marching-squares"
+path = "examples/07-marching-squares/main.rs"
+
+[[example]]
 name = "filewatch"
 
 [dependencies]

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -16,6 +16,10 @@ use noire::{core::{FpsTimer, Timer}, render::{OpenGLWindow, RenderWindow, Size, 
 use std::time::Instant;
 use cgmath::{Vector3, Matrix3, InnerSpace, Rad, Matrix4, Vector4, Deg};
 
+fn lerp(v0: f32, v1: f32, t: f32) -> f32 {
+    (1.0 - t) * v0 + t * v1
+}
+
 fn get_state(a: i32, b: i32, c: i32, d: i32) -> i32 {
     a * 8 + b * 4 + c * 2 + d
 }
@@ -25,20 +29,19 @@ fn line(canvas: &Canvas2D, l: &Vector2, r: &Vector2) {
 }
 
 fn main() {
-    let window_size = Size::new(600, 600);
+    let window_size = Size::new(800, 800);
     let rez = 10;
 
-    let mut window = RenderWindow::create(&window_size, "Hello This is window")
-        .expect("Failed to create Render Window");
+    let mut window = RenderWindow::create(&window_size, "Hello This is window").unwrap();
     window.enable(Capability::ProgramPointSize);
 
     let timer = Timer::now();
     let mut fps_timer = FpsTimer::now();
 
-    let mut canvas = Canvas2D::new(600, 600);
+    let mut canvas = Canvas2D::new(800, 800);
     let noise = OpenSimplexNoise::new(0);
 
-    let rez = 10.0;
+    let rez = 15.0;
     let cols = 1 + canvas.width / (rez as u32);
     let rows = 1 + canvas.height / (rez as u32);
 
@@ -89,6 +92,11 @@ fn main() {
                 let x = (i as f32) * rez;
                 let y = (j as f32) * rez;
 
+                let a_val = field[index as usize] + 1.0;
+                let b_val = field[(index + 1) as usize] + 1.0;
+                let c_val = field[(index + cols + 1) as usize] + 1.0;
+                let d_val = field[(index + cols) as usize] + 1.0;
+
                 let a = Vector2::new(x + rez * 0.5, y            );
                 let b = Vector2::new(x + rez      , y + rez * 0.5);
                 let c = Vector2::new(x + rez * 0.5, y + rez      );
@@ -100,6 +108,18 @@ fn main() {
                     field[(index + cols + 1) as usize].ceil() as i32,
                     field[(index + cols) as usize].ceil() as i32,
                 );
+
+                let amt = (1.0 - a_val) / (b_val - a_val);
+                let a = Vector2::new(lerp(x, x + rez, amt), y);
+
+                let amt = (1.0 - b_val) / (c_val - b_val);
+                let b = Vector2::new(x + rez, lerp(y, y + rez, amt));
+
+                let amt = (1.0 - d_val) / (c_val - d_val);
+                let c = Vector2::new(lerp(x, x + rez, amt), y + rez);
+
+                let amt = (1.0 - a_val) / (d_val - a_val);
+                let d = Vector2::new(x, lerp(y, y + rez, amt));
 
                 match state {
                     1 => {line(&canvas, &c, &d); },
@@ -120,7 +140,6 @@ fn main() {
                 };
             }
         }
-
 
         canvas.render();
         canvas.unbind();

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -12,56 +12,52 @@ use gl::types::*;
 use opensimplex::OpenSimplexNoise;
 use noire::canvas::Canvas2D;
 use noire::math::{Color, PerlinNoise, random_f32, Rect};
-use noire::{core::Timer, render::{OpenGLWindow, RenderWindow, Size, Window, Capability, Program, VertexArrayObject, Bindable, Drawable, Uniform}};
+use noire::{core::{FpsTimer, Timer}, render::{OpenGLWindow, RenderWindow, Size, Window, Capability, Program, VertexArrayObject, Bindable, Drawable, Uniform}};
 use std::time::Instant;
 use cgmath::{Vector3, Vector2, Matrix3, InnerSpace, Rad, Matrix4, Vector4, Deg};
 
 fn main() {
-    let window_size = Size::new(800, 800);
+    let window_size = Size::new(600, 600);
+    let rez = 10;
+
     let mut window = RenderWindow::create(&window_size, "Hello This is window")
         .expect("Failed to create Render Window");
 
     let timer = Timer::now();
+    let mut fps_timer = FpsTimer::now();
 
-    let mut canvas = Canvas2D::new();
-    let opensimplex = OpenSimplexNoise::new(0);
-
-    let mut zoff = 0.0;
+    let mut canvas = Canvas2D::new(600, 600);
+    let noise = PerlinNoise::new(0);
 
     loop {
         let elapsed = timer.elapsed_in_seconds() as f32;
 
+        fps_timer.next_frame();
+        println!("FPS: {}", fps_timer.fps());
+
         let size = window.get_framebuffer_size();
         window.reset_viewport();
         window.clear(0.3, 0.3, 0.3, 1.0);
-        canvas.set_color(Color::rgb(1.0, 0.0, 0.0));
+        // canvas.set_color(Color::rgb(1.0, 0.0, 0.0));
 
         let increment = 0.04;
         let mut yoff = 0.5;
 
-        // render OpenSimplex noise
-        for y in 0..size.height / 4 {
+        // render to canvas
+        canvas.bind();
+        for y in 0..size.height {
             let mut xoff = 0.0;
 
-            for x in 0..size.width / 4 {
+            for x in 0..size.width {
                 let index = x + y * size.width;
-                let r = 0.5 + (opensimplex.noise4_classic(xoff, yoff, zoff, 0.0) / 2.0) as f32;
-
-                canvas.set_color(Color::rgb(r, r, r));
-                canvas.draw_rect(
-                    (x * 4) as i32,
-                    (y * 4) as i32,
-                    ((x + 1) * 4) as i32,
-                    ((y + 1) * 4) as i32
-                );
+                // let r = 0.5 + noise.gen2(xoff, yoff) as f32;
 
                 xoff += increment;
             }
 
             yoff += increment;
         }
-
-        zoff += 0.01;
+        canvas.unbind();
 
         canvas.render(&size);
 

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -11,10 +11,18 @@ use gl::types::*;
 
 use opensimplex::OpenSimplexNoise;
 use noire::canvas::Canvas2D;
-use noire::math::{Color, PerlinNoise, random_f32, Rect};
+use noire::math::{Color, PerlinNoise, random_f32, Rect, Vector2};
 use noire::{core::{FpsTimer, Timer}, render::{OpenGLWindow, RenderWindow, Size, Window, Capability, Program, VertexArrayObject, Bindable, Drawable, Uniform}};
 use std::time::Instant;
-use cgmath::{Vector3, Vector2, Matrix3, InnerSpace, Rad, Matrix4, Vector4, Deg};
+use cgmath::{Vector3, Matrix3, InnerSpace, Rad, Matrix4, Vector4, Deg};
+
+fn get_state(a: i32, b: i32, c: i32, d: i32) -> i32 {
+    a * 8 + b * 4 + c * 2 + d
+}
+
+fn line(canvas: &Canvas2D, l: &Vector2, r: &Vector2) {
+    canvas.draw_line(l.x, l.y, r.x, r.y);
+}
 
 fn main() {
     let window_size = Size::new(600, 600);
@@ -30,16 +38,16 @@ fn main() {
     let mut canvas = Canvas2D::new(600, 600);
     let noise = PerlinNoise::new(0);
 
-    let rez = 20;
-    let cols = 1 + canvas.width / rez;
-    let rows = 1 + canvas.height / rez;
+    let rez = 20.0;
+    let cols = 1 + canvas.width / (rez as u32);
+    let rows = 1 + canvas.height / (rez as u32);
 
     // initialize field values
-    let mut field = vec![0.0; (cols * rows) as usize];
+    let mut field = vec![0; (cols * rows) as usize];
     for x in 0..cols {
         for y in 0..rows {
             let index = x + y * cols;
-            field[index as usize] = random_f32(2.0).floor();
+            field[index as usize] = random_f32(2.0).floor() as i32;
         }
     }
 
@@ -55,16 +63,61 @@ fn main() {
 
         // render to canvas
         canvas.bind();
-        canvas.set_pointsize(rez as f32 * 0.35);
+
+        // render all points
+        canvas.set_pointsize(rez * 0.35);
         for x in 0..cols {
             for y in 0..rows {
                 let index = x + y * cols;
                 let r = field[index as usize] as f32;
 
                 canvas.set_color(Color::rgb(r, r,r ));
-                canvas.draw_point((x * rez) as i32, (y * rez) as i32);
+                canvas.draw_point(x as f32 * rez, y as f32 * rez);
             }
         }
+
+        // render all iso lines, the contour
+        canvas.set_color(Color::rgb(1.0, 1.0, 1.0));
+
+        for i in 0..(cols - 1) {
+            for j in 0..(rows - 1) {
+                let index = i + j * cols;
+                let x = (i as f32) * rez;
+                let y = (j as f32) * rez;
+
+                let a = Vector2::new(x + rez * 0.5, y            );
+                let b = Vector2::new(x + rez      , y + rez * 0.5);
+                let c = Vector2::new(x + rez * 0.5, y + rez      );
+                let d = Vector2::new(x            , y + rez * 0.5);
+
+                let state = get_state(
+                    field[index as usize],
+                    field[(index + 1) as usize],
+                    field[(index + cols + 1) as usize],
+                    field[(index + cols) as usize],
+                );
+
+                match state {
+                    1 => {line(&canvas, &c, &d); },
+                    2 => {line(&canvas, &b, &c); },
+                    3 => {line(&canvas, &b, &d); },
+                    4 => {line(&canvas, &a, &b); },
+                    5 => {line(&canvas, &a, &d); line(&canvas, &b, &c); },
+                    6 => {line(&canvas, &a, &c); },
+                    7 => {line(&canvas, &a, &d); },
+                    8 => {line(&canvas, &a, &d); },
+                    9 => {line(&canvas, &a, &c); },
+                    10 => {line(&canvas, &a, &b); line(&canvas, &c, &d); },
+                    11 => {line(&canvas, &a, &b); },
+                    12 => {line(&canvas, &b, &d); },
+                    13 => {line(&canvas, &b, &c); },
+                    14 => {line(&canvas, &c, &d); },
+                    _ => (),
+                };
+            }
+        }
+
+
         canvas.render();
         canvas.unbind();
 

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -25,7 +25,7 @@ fn line(canvas: &Canvas2D, l: &Vector2, r: &Vector2) {
 }
 
 fn main() {
-    let window_size = Size::new(800, 800);
+    let window_size = Size::new(600, 600);
     let rez = 10;
 
     let mut window = RenderWindow::create(&window_size, "Hello This is window")
@@ -35,7 +35,7 @@ fn main() {
     let timer = Timer::now();
     let mut fps_timer = FpsTimer::now();
 
-    let mut canvas = Canvas2D::new(800, 800);
+    let mut canvas = Canvas2D::new(600, 600);
     let noise = OpenSimplexNoise::new(0);
 
     let rez = 10.0;
@@ -73,7 +73,7 @@ fn main() {
                 field[index as usize] = r;
 
                 canvas.set_color(Color::rgb(r, r,r ));
-                canvas.draw_point((x as f32) * rez, (y as f32) * rez);
+                canvas.draw_rect(x as f32 * rez, y as f32 * rez, x as f32 * rez + rez, y as f32 * rez + rez);
 
                 yoff += increment;
             }

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -22,12 +22,26 @@ fn main() {
 
     let mut window = RenderWindow::create(&window_size, "Hello This is window")
         .expect("Failed to create Render Window");
+    window.enable(Capability::ProgramPointSize);
 
     let timer = Timer::now();
     let mut fps_timer = FpsTimer::now();
 
     let mut canvas = Canvas2D::new(600, 600);
     let noise = PerlinNoise::new(0);
+
+    let rez = 20;
+    let cols = 1 + canvas.width / rez;
+    let rows = 1 + canvas.height / rez;
+
+    // initialize field values
+    let mut field = vec![0.0; (cols * rows) as usize];
+    for x in 0..cols {
+        for y in 0..rows {
+            let index = x + y * cols;
+            field[index as usize] = random_f32(2.0).floor();
+        }
+    }
 
     loop {
         let elapsed = timer.elapsed_in_seconds() as f32;
@@ -37,29 +51,22 @@ fn main() {
 
         let size = window.get_framebuffer_size();
         window.reset_viewport();
-        window.clear(0.3, 0.3, 0.3, 1.0);
-        // canvas.set_color(Color::rgb(1.0, 0.0, 0.0));
-
-        let increment = 0.04;
-        let mut yoff = 0.5;
+        window.clear(0.4, 0.4, 0.4, 1.0);
 
         // render to canvas
         canvas.bind();
-        for y in 0..size.height {
-            let mut xoff = 0.0;
+        canvas.set_pointsize(rez as f32 * 0.35);
+        for x in 0..cols {
+            for y in 0..rows {
+                let index = x + y * cols;
+                let r = field[index as usize] as f32;
 
-            for x in 0..size.width {
-                let index = x + y * size.width;
-                // let r = 0.5 + noise.gen2(xoff, yoff) as f32;
-
-                xoff += increment;
+                canvas.set_color(Color::rgb(r, r,r ));
+                canvas.draw_point((x * rez) as i32, (y * rez) as i32);
             }
-
-            yoff += increment;
         }
+        canvas.render();
         canvas.unbind();
-
-        canvas.render(&size);
 
         window.swap_buffers();
         window.poll_events();

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -1,0 +1,74 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+
+extern crate cgmath;
+extern crate gl;
+extern crate noire;
+extern crate notify;
+
+use gl::types::*;
+
+use opensimplex::OpenSimplexNoise;
+use noire::canvas::Canvas2D;
+use noire::math::{Color, PerlinNoise, random_f32, Rect};
+use noire::{core::Timer, render::{OpenGLWindow, RenderWindow, Size, Window, Capability, Program, VertexArrayObject, Bindable, Drawable, Uniform}};
+use std::time::Instant;
+use cgmath::{Vector3, Vector2, Matrix3, InnerSpace, Rad, Matrix4, Vector4, Deg};
+
+fn main() {
+    let window_size = Size::new(800, 800);
+    let mut window = RenderWindow::create(&window_size, "Hello This is window")
+        .expect("Failed to create Render Window");
+
+    let timer = Timer::now();
+
+    let mut canvas = Canvas2D::new();
+    let opensimplex = OpenSimplexNoise::new(0);
+
+    let mut zoff = 0.0;
+
+    loop {
+        let elapsed = timer.elapsed_in_seconds() as f32;
+
+        let size = window.get_framebuffer_size();
+        window.reset_viewport();
+        window.clear(0.3, 0.3, 0.3, 1.0);
+        canvas.set_color(Color::rgb(1.0, 0.0, 0.0));
+
+        let increment = 0.04;
+        let mut yoff = 0.5;
+
+        // render OpenSimplex noise
+        for y in 0..size.height / 4 {
+            let mut xoff = 0.0;
+
+            for x in 0..size.width / 4 {
+                let index = x + y * size.width;
+                let r = 0.5 + (opensimplex.noise4_classic(xoff, yoff, zoff, 0.0) / 2.0) as f32;
+
+                canvas.set_color(Color::rgb(r, r, r));
+                canvas.draw_rect(
+                    (x * 4) as i32,
+                    (y * 4) as i32,
+                    ((x + 1) * 4) as i32,
+                    ((y + 1) * 4) as i32
+                );
+
+                xoff += increment;
+            }
+
+            yoff += increment;
+        }
+
+        zoff += 0.01;
+
+        canvas.render(&size);
+
+        window.swap_buffers();
+        window.poll_events();
+        if window.should_close() {
+            return;
+        }
+    }
+}

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -145,9 +145,9 @@ impl Canvas2D {
     /// Renders the content of the canvas.
     /// The function resizes the Renderbuffer if the framebuffer size is different
     pub fn render(&mut self) {
-        self.render_points();
-        self.render_lines();
         self.render_rects();
+        self.render_lines();
+        self.render_points();
     }
 
     /// Renders all points

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -98,46 +98,46 @@ impl Canvas2D {
     }
 
     /// Draws a point
-    pub fn draw_point(&self, x: i32, y: i32) -> &Self {
+    pub fn draw_point(&self, x: f32, y: f32) -> &Self {
         let mut points = self.point_vertices.borrow_mut();
-        points.push(x as f32);
-        points.push(y as f32);
+        points.push(x);
+        points.push(y);
         points.append(&mut self.draw_color.rgb_vec());
         self
     }
 
     /// Draws a line
-    pub fn draw_line(&self, start_x: i32, start_y: i32, end_x: i32, end_y: i32) -> &Self {
+    pub fn draw_line(&self, start_x: f32, start_y: f32, end_x: f32, end_y: f32) -> &Self {
         let mut lines = self.line_vertices.borrow_mut();
-        lines.push(start_x as f32);
-        lines.push(start_y as f32);
+        lines.push(start_x);
+        lines.push(start_y);
         lines.append(&mut self.draw_color.rgb_vec());
-        lines.push(end_x as f32);
-        lines.push(end_y as f32);
+        lines.push(end_x);
+        lines.push(end_y);
         lines.append(&mut self.draw_color.rgb_vec());
         self
     }
 
     /// Pushes the geometry for a rect, to be rendered
-    pub fn draw_rect(&self, left: i32, top: i32, right: i32, bottom: i32) -> &Self {
+    pub fn draw_rect(&self, left: f32, top: f32, right: f32, bottom: f32) -> &Self {
         let mut rects = self.rect_vertices.borrow_mut();
-        rects.push(left as f32);
-        rects.push(top as f32);
+        rects.push(left);
+        rects.push(top);
         rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(right as f32);
-        rects.push(top as f32);
+        rects.push(right);
+        rects.push(top);
         rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(right as f32);
-        rects.push(bottom as f32);
+        rects.push(right);
+        rects.push(bottom);
         rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(right as f32);
-        rects.push(bottom as f32);
+        rects.push(right);
+        rects.push(bottom);
         rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(left as f32);
-        rects.push(bottom as f32);
+        rects.push(left);
+        rects.push(bottom);
         rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(left as f32);
-        rects.push(top as f32);
+        rects.push(left);
+        rects.push(top);
         rects.append(&mut self.draw_color.rgb_vec());
         self
     }

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use crate::math::Color;
 use crate::render::{Primitive, Program, Shader, VertexArrayObject, VertexBuffer};
-use crate::render::{Bindable, Drawable, Size, Uniform, vertex_buffer::{VertexType, VertexData}};
+use crate::render::{Bindable, Drawable, vertex_buffer::{VertexType, VertexData}, Uniform};
 
 static VERTEX_SHADER: &str = r#"
 #version 330
@@ -37,6 +37,10 @@ void main() {
 "#;
 
 pub struct Canvas2D {
+    /// Width of the Canvas2D
+    pub width: u32,
+    /// Height of the Canvas2D
+    pub height: u32,
     /// compiled shader program to render primitives
     program: Program,
     /// color to render the next primitive with
@@ -61,10 +65,12 @@ fn compile_program() -> Program {
 
 impl Canvas2D {
     /// Create a new instance of the canvas
-    pub fn new() -> Self {
+    pub fn new(width: u32, height: u32) -> Self {
         let program = compile_program();
 
         Canvas2D {
+            width,
+            height,
             program,
             draw_color: Color::BLACK,
             point_size: 1.0,
@@ -137,14 +143,15 @@ impl Canvas2D {
     }
 
     /// Renders the content of the canvas.
-    pub fn render(&mut self, framebuffer_size: &Size<u32>) {
-        self.render_points(framebuffer_size);
-        self.render_lines(framebuffer_size);
-        self.render_rects(framebuffer_size);
+    /// The function resizes the Renderbuffer if the framebuffer size is different
+    pub fn render(&mut self) {
+        self.render_points();
+        self.render_lines();
+        self.render_rects();
     }
 
     /// Renders all points
-    fn render_points(&mut self, size: &Size<u32>) {
+    fn render_points(&mut self) {
         let mut points = self.point_vertices.borrow_mut();
 
         if !points.is_empty() {
@@ -155,24 +162,16 @@ impl Canvas2D {
             let mut vao = VertexArrayObject::new(Primitive::Points);
             vao.add_vb(vb);
 
-            // bind resources, uniforms, attributes
-            self.program.bind();
-            self.program.uniform("u_pointSize", Uniform::Float(self.point_size));
-            self.program.uniform("u_resolution", Uniform::Float2(size.width as f32, size.height as f32));
-
             vao.bind();
             vao.draw();
             vao.unbind();
-
-            // unbind resources
-            self.program.unbind();
 
             points.clear();
         }
     }
 
     /// Renders all lines using VertexBuffer and VAO
-    fn render_lines(&mut self, size: &Size<u32>) {
+    fn render_lines(&mut self) {
         let mut lines = self.line_vertices.borrow_mut();
 
         if !lines.is_empty() {
@@ -183,23 +182,16 @@ impl Canvas2D {
             let mut vao = VertexArrayObject::new(Primitive::Lines);
             vao.add_vb(vb);
 
-            // bind resources, uniforms, attributes
-            self.program.bind();
-            self.program.uniform("u_resolution", Uniform::Float2(size.width as f32, size.height as f32));
-
             vao.bind();
             vao.draw();
             vao.unbind();
-
-            // unbind resources
-            self.program.unbind();
 
             lines.clear();
         }
     }
 
     /// Renders all rects using VertexBuffer and VAO
-    fn render_rects(&mut self, size: &Size<u32>) {
+    fn render_rects(&mut self) {
         let mut rects = self.rect_vertices.borrow_mut();
 
         if !rects.is_empty() {
@@ -210,18 +202,29 @@ impl Canvas2D {
             let mut vao = VertexArrayObject::new(Primitive::Triangles);
             vao.add_vb(vb);
 
-            // bind resources, uniforms, attributes
-            self.program.bind();
-            self.program.uniform("u_resolution", Uniform::Float2(size.width as f32, size.height as f32));
-
             vao.bind();
             vao.draw();
             vao.unbind();
 
-            // unbind resources
-            self.program.unbind();
-
             rects.clear();
         }
+    }
+}
+
+impl Bindable for Canvas2D {
+    fn bind(&mut self) -> &mut Self {
+        self.program.bind();
+        self.program.uniform("u_resolution", Uniform::Float2(self.width as f32, self.height as f32));
+        self.program.uniform("u_pointSize", Uniform::Float(self.point_size));
+        self
+    }
+
+    fn unbind(&mut self) -> &mut Self {
+        self.program.unbind();
+        self
+    }
+
+    fn bound(&self) -> bool {
+        todo!()
     }
 }

--- a/src/render/capabilities.rs
+++ b/src/render/capabilities.rs
@@ -48,6 +48,8 @@ pub struct Capabilities {
     pub forward_compatible: bool,
     /// Maximum texture size
     pub max_texture_size: Size<usize>,
+    /// Maximum number of color attachments to a FBO
+    pub max_color_attachments: usize,
 }
 
 /// Fetches the Vendor string from OpenGL
@@ -91,6 +93,13 @@ unsafe fn get_shader_version() -> Result<String, CapabilityError> {
     Ok(String::from_utf8(CStr::from_ptr(s as *const _).to_bytes().to_vec())?)
 }
 
+/// Returns the number of max color attachments
+unsafe fn get_max_color_attachments() -> Result<usize, CapabilityError> {
+    let mut attachments = 0;
+    gl::GetIntegerv(gl::MAX_COLOR_ATTACHMENTS, &mut attachments);
+    Ok(attachments as usize)
+}
+
 impl Capabilities {
     /// enumerate some of the OpenGL capabilities
     pub fn enumerate() -> Result<Self, CapabilityError> {
@@ -100,6 +109,7 @@ impl Capabilities {
         let shader_version = unsafe { get_shader_version()? };
         let (debug, forward_compatible) = unsafe { get_context_flags() };
         let max_texture_size = unsafe { get_max_texture_size() };
+        let max_color_attachments = unsafe { get_max_color_attachments()? };
 
         Ok(Capabilities {
             vendor,
@@ -109,6 +119,7 @@ impl Capabilities {
             debug,
             forward_compatible,
             max_texture_size,
+            max_color_attachments,
         })
     }
 }

--- a/src/render/frame_buffer.rs
+++ b/src/render/frame_buffer.rs
@@ -44,6 +44,7 @@ fn check_status() -> Result<(), RenderError> {
     Ok(())
 }
 
+/// Returns the error string based on given Framebuffer error code
 fn status_error(error: u32) -> String {
     match error {
         gl::FRAMEBUFFER_UNSUPPORTED => "Framebuffer is not supported".to_string(),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -25,9 +25,9 @@ pub mod opengl;
 pub mod program;
 pub mod render_buffer;
 pub mod shader;
+pub mod spot_light;
 pub mod texture;
 pub mod traits;
-pub mod spot_light;
 pub mod vertex;
 pub mod vertex_buffer;
 pub mod window;
@@ -142,7 +142,7 @@ impl From<Primitive> for gl::types::GLenum {
     }
 }
 
-/// Texture format
+/// Texture & Pixel format
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u32)]
 pub enum Format {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -67,7 +67,7 @@ impl error::Error for RenderError {
 }
 
 /// Struct to provide size dimensions
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Size<T> {
     /// width
     pub width: T,

--- a/src/render/window.rs
+++ b/src/render/window.rs
@@ -161,7 +161,7 @@ pub fn set_fullscreen(glfw: &mut Glfw, window: &mut glfw::Window, mode: Fullscre
 }
 
 /// Initializes GLFW and returns it
-fn init_glfw() -> Result<Glfw, WindowError> {
+fn init_glfw(resizable: bool) -> Result<Glfw, WindowError> {
     let callback = glfw::Callback {
         f: glfw_error_callback as fn(glfw::Error, String, &Cell<usize>),
         data: Cell::new(0),
@@ -192,7 +192,7 @@ impl RenderWindow {
 
     /// Creates a windowed RenderWindow with given size
     pub fn create(size: &Size<u32>, title: &str) -> Result<RenderWindow, WindowError> {
-        let mut glfw = init_glfw()?;
+        let mut glfw = init_glfw(false)?;
 
         let (mut window, events) =
             match glfw.create_window(size.width, size.height, title, glfw::WindowMode::Windowed) {


### PR DESCRIPTION
This adds a new sample application to render marching squares. The code is based on a recent episode of the fabulous [Coding Train](https://thecodingtrain.com/), Coding in the Cabana Nr 5 on [Marching Squares](https://www.youtube.com/watch?v=0ZONMNUKTfU). The algorithm is well explained in detail, shown in Processing but it's quite easy to follow and easy to port the code to other Canvas-like graphics environments.

Here are some useful resources

* [The Coding Train](https://thecodingtrain.com/)
* [Wikipedia article on Marching Squares](https://en.wikipedia.org/wiki/Marching_squares)
* The excellent article on [Metaballs and Marching Squares](http://jamie-wong.com/2014/08/19/metaballs-and-marching-squares/) by Jamie Wong