### PR TITLE
Extend vertex buffer

### DIFF
--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -18,8 +18,8 @@ impl Mesh {
     pub fn create_cube(cube: Cube, color: Color) -> Result<Mesh, RenderError> {
         let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
-        vao.add_vb(VertexBuffer::create(&cube.vertices, 3));
-        vao.add_vb(VertexBuffer::create(&cube.normals, 3));
+        vao.add_vb(VertexBuffer::create(&cube.vertices, &[3]));
+        vao.add_vb(VertexBuffer::create(&cube.normals, &[3]));
         vao.add_ib(IndexBuffer::create(&cube.indices)?);
 
         Ok(Mesh {
@@ -32,8 +32,8 @@ impl Mesh {
     pub fn create_plane(plane: Plane, color: Color) -> Result<Mesh, RenderError> {
         let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
-        vao.add_vb(VertexBuffer::create(&plane.vertices, 3));
-        vao.add_vb(VertexBuffer::create(&plane.normals, 3));
+        vao.add_vb(VertexBuffer::create(&plane.vertices, &[3]));
+        vao.add_vb(VertexBuffer::create(&plane.normals, &[3]));
         vao.add_ib(IndexBuffer::create(&plane.indices)?);
 
         Ok(Mesh {

--- a/src/mesh/screen_rect.rs
+++ b/src/mesh/screen_rect.rs
@@ -77,8 +77,8 @@ impl ScreenRect {
     pub fn new() -> Result<Self, RenderError> {
         let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
-        vao.add_vb(VertexBuffer::create(&create_vertices(), 2));
-        vao.add_vb(VertexBuffer::create(&create_texcoords(), 2));
+        vao.add_vb(VertexBuffer::create(&create_vertices(), &[2]));
+        vao.add_vb(VertexBuffer::create(&create_texcoords(), &[2]));
 
         let program = create_program()?;
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -39,7 +39,7 @@ impl VertexArrayObject {
 
     /// Create a 2-dimensional rect, in range between -1..+1
     pub fn screen_rect() -> Self {
-        let vb = VertexBuffer::create(&VERTICES, 2);
+        let vb = VertexBuffer::create(&VERTICES, &[2]);
         let ib = IndexBuffer::create(&INDICES).unwrap();
 
         let mut vao = VertexArrayObject::new(Primitive::TriangleStrip);

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -134,8 +134,10 @@ impl VertexBuffer {
     /// Creates a new empty Vertex Buffer with vertex layout but without any existing data
     /// This function is useful to pre-allocate a large enough buffer that needs updates later.
     pub fn with_size(count: usize, components: Vec<u32>) -> Self {
-        let mut id = 0;
-        unsafe { gl::GenBuffers(1, &mut id) };
+        let num_components = components.iter().sum::<u32>();
+        let id = unsafe {
+            generate_buffer(&vec![0.0; count * num_components as usize])
+        };
 
         Self {
             id,
@@ -158,15 +160,9 @@ impl VertexBuffer {
     }
 
     /// Creates a new VertexBuffer from a float array
-    pub fn create(data: &[f32], num_components: usize) -> Self {
-        let id = unsafe { generate_buffer(data) };
-
-        Self {
-            id,
-            count: data.len() / num_components,
-            components: vec![num_components as u32],
-            vertex_type: VertexType::Float,
-        }
+    pub fn create(data: &[f32], components: &[u32]) -> Self {
+        let vertex_data = VertexData::new(data, &components, VertexType::Float);
+        Self::new(&vertex_data)
     }
 
     /// Returns the size of the VertexBuffer

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -131,11 +131,25 @@ unsafe fn generate_buffer(data: &[f32]) -> u32 {
 }
 
 impl VertexBuffer {
+    /// Creates a new empty Vertex Buffer with vertex layout but without any existing data
+    /// This function is useful to pre-allocate a large enough buffer that needs updates later.
+    pub fn with_size(count: usize, components: Vec<u32>) -> Self {
+        let mut id = 0;
+        unsafe { gl::GenBuffers(1, &mut id) };
+
+        Self {
+            id,
+            count,
+            components,
+            vertex_type: VertexType::Float,
+        }
+    }
+
     /// Constructs a new Vertex Buffer from Vertex Data
     pub fn new(vertex_data: &VertexData) -> Self {
         let id = unsafe { generate_buffer(vertex_data.data) };
 
-        VertexBuffer {
+        Self {
             id,
             count: vertex_data.count(),
             components: vertex_data.components.clone(),
@@ -147,7 +161,7 @@ impl VertexBuffer {
     pub fn create(data: &[f32], num_components: usize) -> Self {
         let id = unsafe { generate_buffer(data) };
 
-        VertexBuffer {
+        Self {
             id,
             count: data.len() / num_components,
             components: vec![num_components as u32],
@@ -155,18 +169,22 @@ impl VertexBuffer {
         }
     }
 
+    /// Returns the size of the VertexBuffer
     pub fn size(&self) -> usize {
         self.count
     }
 
+    /// Returns the number of (Float) components
     pub fn num_components(&self) -> u32 {
         self.components.iter().sum()
     }
 
+    /// Returns the components part, e.g. (x,y,z,tx,ty,r,g,b) -> [3,2,3]
     pub fn components(&self) -> &Vec<u32> {
         &self.components
     }
 
+    /// Returns the vertex type, in most cases Float
     pub fn vertex_type(&self) -> VertexType {
         self.vertex_type
     }


### PR DESCRIPTION
This extends and refactors the VertexBuffer struct.

* add constructor to allocate a dynamic VertexBuffer
* add functions to write vertex data to VertexBuffer, not only during initialization
* refactor components parameter to be a array
* add documentation