### PR TITLE
Refactor Canvas primitive rendering

### DIFF
--- a/examples/06-opensimplex/main.rs
+++ b/examples/06-opensimplex/main.rs
@@ -62,7 +62,7 @@ fn main() {
 
         zoff += 0.01;
 
-        canvas.render();
+        // canvas.render();
         canvas.unbind();
 
         window.swap_buffers();

--- a/examples/06-opensimplex/main.rs
+++ b/examples/06-opensimplex/main.rs
@@ -49,7 +49,7 @@ fn main() {
 
             for x in 0..size.width / 4 {
                 let index = x + y * size.width;
-                let r = 0.5 + (opensimplex.noise4_classic(xoff, yoff, zoff, 0.0) / 2.0) as f32;
+                let r = 0.5 + (opensimplex.noise4_classic(xoff, yoff, 0.0, zoff) / 2.0) as f32;
 
                 canvas.set_color(Color::rgb(r, r, r));
                 canvas.draw_rect((x * 4) as f32, (y * 4) as f32, ((x + 1) * 4) as f32, ((y + 1) * 4) as f32);

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -40,11 +40,12 @@ fn main() {
     let mut canvas = Canvas2D::new(800, 800);
     let noise = OpenSimplexNoise::new(0);
 
-    let rez = 8.0;
+    let rez = 6.0;
     let cols = 1 + canvas.width / (rez as u32);
     let rows = 1 + canvas.height / (rez as u32);
 
-    let increment = 0.1;
+    let increment = 0.04;
+    let zincrement = 0.0025;
     let mut zoff = 0.0;
 
     let mut field: Vec<f32> = vec![0.0; (cols * rows) as usize];
@@ -80,7 +81,7 @@ fn main() {
                 yoff += increment;
             }
         }
-        zoff += 0.01;
+        zoff += zincrement;
 
         // render all iso lines, the contour
         canvas.set_color(Color::rgb(1.0, 1.0, 1.0));

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -24,7 +24,7 @@ fn get_state(a: i32, b: i32, c: i32, d: i32) -> i32 {
     a * 8 + b * 4 + c * 2 + d
 }
 
-fn line(canvas: &Canvas2D, l: &Vector2, r: &Vector2) {
+fn line(canvas: &mut Canvas2D, l: &Vector2, r: &Vector2) {
     canvas.draw_line(l.x, l.y, r.x, r.y);
 }
 
@@ -121,20 +121,20 @@ fn main() {
                 let d = Vector2::new(x, lerp(y, y + rez, amt));
 
                 match state {
-                    1 => {line(&canvas, &c, &d); },
-                    2 => {line(&canvas, &b, &c); },
-                    3 => {line(&canvas, &b, &d); },
-                    4 => {line(&canvas, &a, &b); },
-                    5 => {line(&canvas, &a, &d); line(&canvas, &b, &c); },
-                    6 => {line(&canvas, &a, &c); },
-                    7 => {line(&canvas, &a, &d); },
-                    8 => {line(&canvas, &a, &d); },
-                    9 => {line(&canvas, &a, &c); },
-                    10 => {line(&canvas, &a, &b); line(&canvas, &c, &d); },
-                    11 => {line(&canvas, &a, &b); },
-                    12 => {line(&canvas, &b, &d); },
-                    13 => {line(&canvas, &b, &c); },
-                    14 => {line(&canvas, &c, &d); },
+                    1 => {line(&mut canvas, &c, &d); },
+                    2 => {line(&mut canvas, &b, &c); },
+                    3 => {line(&mut canvas, &b, &d); },
+                    4 => {line(&mut canvas, &a, &b); },
+                    5 => {line(&mut canvas, &a, &d); line(&mut canvas, &b, &c); },
+                    6 => {line(&mut canvas, &a, &c); },
+                    7 => {line(&mut canvas, &a, &d); },
+                    8 => {line(&mut canvas, &a, &d); },
+                    9 => {line(&mut canvas, &a, &c); },
+                    10 => {line(&mut canvas, &a, &b); line(&mut canvas, &c, &d); },
+                    11 => {line(&mut canvas, &a, &b); },
+                    12 => {line(&mut canvas, &b, &d); },
+                    13 => {line(&mut canvas, &b, &c); },
+                    14 => {line(&mut canvas, &c, &d); },
                     _ => (),
                 };
             }

--- a/examples/07-marching-squares/main.rs
+++ b/examples/07-marching-squares/main.rs
@@ -140,7 +140,6 @@ fn main() {
             }
         }
 
-        canvas.render();
         canvas.unbind();
 
         window.swap_buffers();

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -114,6 +114,7 @@ pub struct Canvas2D {
     point_size: f32,
 
     rects: DrawBatch,
+    lines: DrawBatch,
 
     /// The number of shapes to render
     shapes_count: usize,
@@ -133,6 +134,7 @@ impl Canvas2D {
         let program = compile_program();
 
         let rects = DrawBatch::new(Primitive::Triangles, 6 * 2048);
+        let lines = DrawBatch::new(Primitive::Lines, 1024);
 
         Canvas2D {
             width,
@@ -141,6 +143,7 @@ impl Canvas2D {
             draw_color: Color::BLACK,
             point_size: 1.0,
             rects,
+            lines,
             shapes_count: 0,
         }
     }
@@ -171,7 +174,20 @@ impl Canvas2D {
     }
 
     /// Draws a line
-    pub fn draw_line(&self, start_x: f32, start_y: f32, end_x: f32, end_y: f32) {
+    pub fn draw_line(&mut self, start_x: f32, start_y: f32, end_x: f32, end_y: f32) {
+        let c = &self.draw_color;
+        let data = vec![
+            start_x, start_y, self.zoffset(), c.r, c.g, c.b,
+            end_x, end_y, self.zoffset(), c.r, c.g, c.b,
+        ];
+
+        self.lines.append(&data);
+        if self.lines.filled() {
+            self.lines.draw();
+        }
+
+        self.inc_shapes();
+
         /*
         let mut lines = self.line_vertices.borrow_mut();
         lines.push(start_x);

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -104,7 +104,7 @@ impl Canvas2D {
     pub fn new(width: u32, height: u32) -> Self {
         let program = compile_program();
 
-        let mut vb = VertexBuffer::dynamic(4, vec![2, 3]);
+        let mut vb = VertexBuffer::dynamic(600, vec![2, 3]);
         let vao_handle = unsafe { create_vao(&mut vb) };
 
         Canvas2D {
@@ -165,14 +165,19 @@ impl Canvas2D {
             left, top, c.r, c.g, c.b,
             right, top, c.r, c.g, c.b,
             right, bottom, c.r, c.g, c.b,
+            right, bottom, c.r, c.g, c.b,
             left, bottom, c.r, c.g, c.b,
+            left, top, c.r, c.g, c.b,
         ];
 
-        self.vb.write(&data);
-
-        unsafe {
-            gl::DrawArrays(Primitive::TriangleFan as u32, 0, 4);
+        self.vb.append(&data);
+        if self.vb.full() {
+            unsafe {
+                gl::DrawArrays(Primitive::Triangles as u32, 0, self.vb.size() as i32);
+            }
+            self.vb.clear();
         }
+
     }
 }
 
@@ -190,6 +195,11 @@ impl Bindable for Canvas2D {
     }
 
     fn unbind(&mut self) -> &mut Self {
+        unsafe {
+            gl::DrawArrays(Primitive::TriangleFan as u32, 0, self.vb.size() as i32);
+        }
+        self.vb.clear();
+
         unsafe {
             gl::BindVertexArray(0);
         }

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -119,33 +119,29 @@ impl Canvas2D {
     }
 
     /// Pushes the geometry for a rect, to be rendered
-    pub fn draw_rect(&self, left: f32, top: f32, right: f32, bottom: f32) -> &Self {
-        let mut rects = self.rect_vertices.borrow_mut();
-        rects.push(left);
-        rects.push(top);
-        rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(right);
-        rects.push(top);
-        rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(right);
-        rects.push(bottom);
-        rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(right);
-        rects.push(bottom);
-        rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(left);
-        rects.push(bottom);
-        rects.append(&mut self.draw_color.rgb_vec());
-        rects.push(left);
-        rects.push(top);
-        rects.append(&mut self.draw_color.rgb_vec());
-        self
+    pub fn draw_rect(&self, left: f32, top: f32, right: f32, bottom: f32) {
+        let c = &self.draw_color;
+        let data = vec![
+            left, top, c.r, c.g, c.b,
+            right, top, c.r, c.g, c.b,
+            right, bottom, c.r, c.g, c.b,
+            left, bottom, c.r, c.g, c.b,
+        ];
+
+        let vb = VertexBuffer::create(&data, &[2, 3]);
+        let mut vao = VertexArrayObject::new(Primitive::TriangleFan);
+
+        vao.add_vb(vb);
+        vao.bind();
+        vao.draw();
+        vao.bind();
+
     }
 
     /// Renders the content of the canvas.
     /// The function resizes the Renderbuffer if the framebuffer size is different
     pub fn render(&mut self) {
-        self.render_rects();
+        // self.render_rects();
         self.render_lines();
         self.render_points();
     }

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -11,9 +11,9 @@ static INDICES: [GLuint; 6] = [0, 1, 2, 2, 3, 1];
 /// A struct to represent a OpenGL vertex array object (VAO)
 pub struct VertexArrayObject {
     /// the OpenGL instance id
-    id: u32,
+    pub id: u32,
     /// The used render type
-    primitive_type: Primitive,
+    pub primitive: Primitive,
     /// The list of Vertex Buffers
     vbs: Vec<VertexBuffer>,
     /// The list of Index Buffers,
@@ -22,7 +22,7 @@ pub struct VertexArrayObject {
 
 impl VertexArrayObject {
     /// Create a new instance of a VertexArrayObject
-    pub fn new(primitive_type: Primitive) -> VertexArrayObject {
+    pub fn new(primitive: Primitive) -> VertexArrayObject {
         let mut id = 0;
 
         unsafe {
@@ -31,7 +31,7 @@ impl VertexArrayObject {
 
         VertexArrayObject {
             id,
-            primitive_type,
+            primitive,
             vbs: vec![],
             ibs: vec![],
         }
@@ -58,6 +58,16 @@ impl VertexArrayObject {
     /// Add an index buffer
     pub fn add_ib(&mut self, ib: IndexBuffer) {
         self.ibs.push(ib);
+    }
+
+    /// Returns a reference to the VertexBuffer
+    pub fn get_vb(&self, index: usize) -> Option<&VertexBuffer> {
+        self.vbs.get(index)
+    }
+
+    /// Returns a mutable reference to the VertexBuffer
+    pub fn get_vb_mut(&mut self, index: usize) -> Option<&mut VertexBuffer> {
+        self.vbs.get_mut(index)
     }
 
     /// Sets up vertex buffer arrays and the vertex layout
@@ -158,7 +168,7 @@ impl Drawable for VertexArrayObject {
         let vb = &self.vbs[0];
         if self.ibs.is_empty() {
             unsafe {
-                gl::DrawArrays(self.primitive_type.into(), 0, vb.size() as i32);
+                gl::DrawArrays(self.primitive.into(), 0, vb.size() as i32);
             }
         } else {
             let ib = &self.ibs[0];


### PR DESCRIPTION
This PR tries to improve the `Canvas2D` rendering of primitives. It batches primitives until a threshold is reached before rendering them at once. This may actually lead to visual artifacts when primitives are rendered interleavingly.

This is still in progress and needs refinement later.