### PR TITLE
Refactor vertex attribute and buffer initialisation

### DIFF
--- a/examples/03-raymarching/main.rs
+++ b/examples/03-raymarching/main.rs
@@ -26,12 +26,6 @@ use noire::{core::{Timer, FpsTimer}, input::keyboard::*};
 use std::time::{Duration, Instant};
 use std::collections::VecDeque;
 
-const MAX_FPS_COUNT: u32 = 50;
-
-fn from_duration(d: Duration) -> f32 {
-    (d.as_secs() as f64 + d.subsec_nanos() as f64 * 1e-9) as f32
-}
-
 fn main() {
     let window_size = Size::new(600, 400);
     let mut window = RenderWindow::create(&window_size, "Hello This is window")

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -1,6 +1,6 @@
 use crate::math::Color;
 use crate::render::{Primitive, Program, Shader, VertexBuffer};
-use crate::render::{Uniform, Bindable, Drawable, vertex_buffer::{VertexType, VertexTypeSize}, VertexAttributeDescriptor};
+use crate::render::{Uniform, Bindable, Drawable, vertex_buffer::VertexType, VertexAttributeDescriptor};
 
 static VERTEX_SHADER: &str = r#"
 #version 330
@@ -56,7 +56,7 @@ fn generate_vao(vb: &mut VertexBuffer) -> u32 {
             gl::EnableVertexAttribArray(attribute.location)
         }
 
-        offset += attribute.components * attribute.vertex_type.size();
+        offset += attribute.stride();
     }
 
     unsafe { gl::BindVertexArray(0); }

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -42,22 +42,20 @@ fn generate_vao(vb: &mut VertexBuffer) -> u32 {
 
     vb.bind();
 
-    let mut index = 0;
     let mut offset = 0;
     for attribute in &vb.attributes {
         unsafe {
             gl::VertexAttribPointer(
-                index as u32,
+                attribute.location,
                 attribute.components as i32,
                 attribute.vertex_type.into(),
                 gl::FALSE,
                 vb.stride() as i32,
                 offset as *const gl::types::GLvoid,
             );
-            gl::EnableVertexAttribArray(index)
+            gl::EnableVertexAttribArray(attribute.location)
         }
 
-        index += 1;
         offset += attribute.components * attribute.vertex_type.size();
     }
 

--- a/src/canvas/canvas.rs
+++ b/src/canvas/canvas.rs
@@ -92,13 +92,13 @@ impl VertexBatch {
 
     /// Appends the vertex data
     pub fn append(&mut self, data: &[f32]) {
-        self.vb.write_offset(&data, self.count);
-        self.count += data.len() / self.vb.num_components() as usize;
+        self.vb.write(&data, self.count);
+        self.count += data.len() / self.vb.components() as usize;
     }
 
     /// Returns true if VertexBuffer is filled with vertex data to capacity
     pub fn filled(&self) -> bool {
-        self.count >= self.vb.size() - (self.vb.num_components() * self.vb.stride()) as usize
+        self.count >= self.vb.size() - self.vb.stride() as usize
     }
 
     fn bind(&self) {

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -2,7 +2,7 @@ use super::{Cube, Plane};
 
 use crate::math::Color;
 use crate::render::{Primitive, RenderError};
-use crate::render::{IndexBuffer, VertexBuffer, VertexArrayObject};
+use crate::render::{IndexBuffer, VertexBuffer, VertexArrayObject, VertexAttributeDescriptor, vertex_buffer::VertexType};
 
 /// A basic mesh structure that contains vertex data and some
 /// properties to be used in a scene
@@ -18,8 +18,15 @@ impl Mesh {
     pub fn create_cube(cube: Cube, color: Color) -> Result<Mesh, RenderError> {
         let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
-        vao.add_vb(VertexBuffer::create(&cube.vertices, &[3]));
-        vao.add_vb(VertexBuffer::create(&cube.normals, &[3]));
+        let attributes = vec![
+            VertexAttributeDescriptor::new("position", VertexType::Float, 3, 0),
+        ];
+        vao.add_vb(VertexBuffer::create(&cube.vertices, attributes));
+
+        let attributes = vec![
+            VertexAttributeDescriptor::new("normal", VertexType::Float, 3, 1),
+        ];
+        vao.add_vb(VertexBuffer::create(&cube.normals, attributes));
         vao.add_ib(IndexBuffer::create(&cube.indices)?);
 
         Ok(Mesh {
@@ -32,8 +39,15 @@ impl Mesh {
     pub fn create_plane(plane: Plane, color: Color) -> Result<Mesh, RenderError> {
         let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
-        vao.add_vb(VertexBuffer::create(&plane.vertices, &[3]));
-        vao.add_vb(VertexBuffer::create(&plane.normals, &[3]));
+        let attributes = vec![
+            VertexAttributeDescriptor::new("position", VertexType::Float, 3, 0),
+        ];
+        vao.add_vb(VertexBuffer::create(&plane.vertices, attributes));
+
+        let attributes = vec![
+            VertexAttributeDescriptor::new("normal", VertexType::Float, 3, 0),
+        ];
+        vao.add_vb(VertexBuffer::create(&plane.normals, attributes));
         vao.add_ib(IndexBuffer::create(&plane.indices)?);
 
         Ok(Mesh {

--- a/src/mesh/mesh.rs
+++ b/src/mesh/mesh.rs
@@ -45,7 +45,7 @@ impl Mesh {
         vao.add_vb(VertexBuffer::create(&plane.vertices, attributes));
 
         let attributes = vec![
-            VertexAttributeDescriptor::new("normal", VertexType::Float, 3, 0),
+            VertexAttributeDescriptor::new("normal", VertexType::Float, 3, 1),
         ];
         vao.add_vb(VertexBuffer::create(&plane.normals, attributes));
         vao.add_ib(IndexBuffer::create(&plane.indices)?);

--- a/src/mesh/screen_rect.rs
+++ b/src/mesh/screen_rect.rs
@@ -1,4 +1,4 @@
-use crate::render::{Drawable, VertexArrayObject, VertexBuffer, Point2, Primitive, RenderError, Size, Program, ProgramError, Shader, ShaderType, Texture, Uniform, Bindable, Capability, RenderWindow, OpenGLWindow};
+use crate::render::{Drawable, VertexArrayObject, VertexBuffer, Point2, Primitive, RenderError, Size, Program, ProgramError, Shader, ShaderType, Texture, Uniform, Bindable, Capability, RenderWindow, OpenGLWindow, VertexAttributeDescriptor, vertex_buffer::VertexType};
 
 pub struct ScreenRect {
     /// holds all vertex information
@@ -77,8 +77,11 @@ impl ScreenRect {
     pub fn new() -> Result<Self, RenderError> {
         let mut vao = VertexArrayObject::new(Primitive::Triangles);
 
-        vao.add_vb(VertexBuffer::create(&create_vertices(), &[2]));
-        vao.add_vb(VertexBuffer::create(&create_texcoords(), &[2]));
+        let vertices = VertexAttributeDescriptor::new("position", VertexType::Float, 2, 0);
+        let texcoords = VertexAttributeDescriptor::new("texcoord", VertexType::Float, 2, 1);
+
+        vao.add_vb(VertexBuffer::create(&create_vertices(), vec![vertices]));
+        vao.add_vb(VertexBuffer::create(&create_texcoords(), vec![texcoords]));
 
         let program = create_program()?;
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -14,6 +14,7 @@ pub use self::spot_light::Spotlight;
 pub use self::texture::Texture;
 pub use self::traits::{Bindable, Drawable};
 pub use self::vertex::VertexArrayObject;
+pub use self::vertex_attribute::*;
 pub use self::vertex_buffer::VertexBuffer;
 pub use self::window::{Fullscreen, Pos, RenderWindow, OpenGLWindow, Window};
 
@@ -29,6 +30,7 @@ pub mod spot_light;
 pub mod texture;
 pub mod traits;
 pub mod vertex;
+pub mod vertex_attribute;
 pub mod vertex_buffer;
 pub mod window;
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,7 +15,7 @@ pub use self::texture::Texture;
 pub use self::traits::{Bindable, Drawable};
 pub use self::vertex::VertexArrayObject;
 pub use self::vertex_attribute::*;
-pub use self::vertex_buffer::VertexBuffer;
+pub use self::vertex_buffer::*;
 pub use self::window::{Fullscreen, Pos, RenderWindow, OpenGLWindow, Window};
 
 pub mod capabilities;

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -3,7 +3,7 @@ use std::ptr;
 use gl;
 use gl::types::*;
 
-use super::{IndexBuffer, VertexBuffer, Bindable, Drawable, Primitive, VertexAttributeDescriptor, vertex_buffer::{VertexTypeSize, VertexType}};
+use super::{IndexBuffer, VertexBuffer, Bindable, Drawable, Primitive, VertexAttributeDescriptor, VertexType};
 
 static VERTICES: [GLfloat; 8] = [-1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0];
 static INDICES: [GLuint; 6] = [0, 1, 2, 2, 3, 1];
@@ -93,9 +93,9 @@ impl VertexArrayObject {
                         offset as *const gl::types::GLvoid,
                     );
                     gl::EnableVertexAttribArray(attribute.location);
-
-                    offset += attribute.components * attribute.vertex_type.size()
                 }
+
+                offset += attribute.stride();
             }
         }
 

--- a/src/render/vertex.rs
+++ b/src/render/vertex.rs
@@ -3,7 +3,7 @@ use std::ptr;
 use gl;
 use gl::types::*;
 
-use super::{IndexBuffer, VertexBuffer, Bindable, Drawable, Primitive, VertexAttributeDescriptor, vertex_buffer::VertexType};
+use super::{IndexBuffer, VertexBuffer, Bindable, Drawable, Primitive, VertexAttributeDescriptor, vertex_buffer::{VertexTypeSize, VertexType}};
 
 static VERTICES: [GLfloat; 8] = [-1.0, 1.0, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0];
 static INDICES: [GLuint; 6] = [0, 1, 2, 2, 3, 1];
@@ -81,6 +81,7 @@ impl VertexArrayObject {
 
         for vb in self.vbs.iter_mut() {
             vb.bind();
+            let mut offset = 0;
             for attribute in &vb.attributes {
                 unsafe {
                     gl::VertexAttribPointer(
@@ -89,9 +90,11 @@ impl VertexArrayObject {
                         attribute.vertex_type.into(),
                         gl::FALSE,
                         vb.stride() as i32,
-                        attribute.offset as *const gl::types::GLvoid,
+                        offset as *const gl::types::GLvoid,
                     );
                     gl::EnableVertexAttribArray(attribute.location);
+
+                    offset += attribute.components * attribute.vertex_type.size()
                 }
             }
         }

--- a/src/render/vertex_attribute.rs
+++ b/src/render/vertex_attribute.rs
@@ -1,0 +1,31 @@
+use super::vertex_buffer::{VertexTypeSize, VertexType};
+
+#[derive(Debug)]
+pub struct VertexAttributeDescriptor {
+    /// Named identifier of the list of vertex data
+    pub name: String,
+    /// The vertex type to be referenced, e.g. Float
+    pub vertex_type: VertexType,
+    /// The number of components, e.g. (x, y, z) = 3
+    pub components: u32,
+    /// The offset
+    pub offset: u64,
+    /// The shader location index
+    pub location: u32,
+}
+
+impl VertexAttributeDescriptor {
+    pub fn new(name: &str, vertex_type: VertexType, components: u32, location: u32) -> Self {
+        Self {
+            name: name.into(),
+            vertex_type,
+            components,
+            offset: 0,
+            location,
+        }
+    }
+
+    pub fn stride(&self) -> u32 {
+        self.vertex_type.size() * self.components
+    }
+}

--- a/src/render/vertex_attribute.rs
+++ b/src/render/vertex_attribute.rs
@@ -8,8 +8,6 @@ pub struct VertexAttributeDescriptor {
     pub vertex_type: VertexType,
     /// The number of components, e.g. (x, y, z) = 3
     pub components: u32,
-    /// The offset
-    pub offset: u64,
     /// The shader location index
     pub location: u32,
 }
@@ -20,7 +18,6 @@ impl VertexAttributeDescriptor {
             name: name.into(),
             vertex_type,
             components,
-            offset: 0,
             location,
         }
     }

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -167,9 +167,11 @@ impl VertexBuffer {
         }
     }
 
-    /// Constructs a new static VertexBuffer from the given vertex data
+    /// Creates a new VertexBuffer from given vertex array and components list
     ///
-    pub fn new(vertex_data: &VertexData) -> Self {
+    pub fn create(data: &[f32], components: &[u32]) -> Self {
+        let vertex_data = VertexData::new(data, &components, VertexType::Float);
+
         let id = unsafe { allocate_static_buffer(vertex_data.data) };
 
         Self {
@@ -178,13 +180,6 @@ impl VertexBuffer {
             components: vertex_data.components.clone(),
             vertex_type: vertex_data.vertex_type,
         }
-    }
-
-    /// Creates a new VertexBuffer from given vertex array and components list
-    ///
-    pub fn create(data: &[f32], components: &[u32]) -> Self {
-        let vertex_data = VertexData::new(data, &components, VertexType::Float);
-        Self::new(&vertex_data)
     }
 
     /// Copies vertex data from array into VertexBuffer

--- a/src/render/vertex_buffer.rs
+++ b/src/render/vertex_buffer.rs
@@ -69,37 +69,6 @@ impl VertexTypeSize for VertexType {
 }
 
 #[derive(Debug)]
-pub struct VertexData<'a> {
-    /// Holds the list of vertex data
-    pub data: &'a [f32],
-    /// The vertex data type
-    pub vertex_type: VertexType,
-    /// The number of components, e.g. 3 for x,y,z
-    pub components: Vec<u32>,
-}
-
-impl <'a> VertexData<'a> {
-    pub fn new(data: &'a [f32], components: &[u32], vertex_type: VertexType) -> Self {
-        VertexData {
-            data,
-            vertex_type,
-            components: Vec::from(components),
-        }
-    }
-
-    /// Returns the vertex count of the data array
-    pub fn count(&self) -> usize {
-        self.data.len() / self.num_components()
-    }
-
-    /// Returns the number of different components
-    pub fn num_components(&self) -> usize {
-        let r: u32 = self.components.iter().sum();
-        r as usize
-    }
-}
-
-#[derive(Debug)]
 pub struct VertexBuffer {
     /// Id reference to Open GL allocated buffer
     pub id: u32,


### PR DESCRIPTION
Use a `VertexAttributeDescriptor` to group values in order to provide safer / cleaner logic to set up the layout of vertex attributes in vertex buffers.

* remove `VertexData` struct, not used anymore
* refactor initialisation of VertexBuffers
* re-use functions more appropriately