### PR TITLE
Add FrontFace enum

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -250,11 +250,17 @@ impl From<Capability> for gl::types::GLenum {
 #[repr(u32)]
 pub enum CullMode {
     /// Cull Front face
-    Front = gl::FRONT,
+    Front,
     /// Cull Back face
-    Back = gl::BACK,
+    Back,
     /// Culls both Front and Back faces
-    Both = gl::FRONT_AND_BACK,
+    Both,
+}
+
+impl Default for CullMode {
+    fn default() -> Self {
+        CullMode::Back
+    }
 }
 
 impl From<CullMode> for gl::types::GLenum {
@@ -274,6 +280,40 @@ impl From<gl::types::GLenum> for CullMode {
             gl::BACK => CullMode::Back,
             gl::FRONT_AND_BACK => CullMode::Both,
             _ => panic!("Unknown cull mode found: {}", cull_mode),
+        }
+    }
+}
+
+/// Defines the front face order
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+pub enum FrontFace {
+    /// Counter Clock wise
+    Ccw = 0,
+    /// Clock wise
+    Cw = 1,
+}
+
+impl Default for FrontFace {
+    fn default() -> Self {
+        FrontFace::Ccw
+    }
+}
+
+impl From<FrontFace> for gl::types::GLenum {
+    fn from(front_face: FrontFace) -> Self {
+        match front_face {
+            FrontFace::Ccw => gl::CCW,
+            FrontFace::Cw => gl::CW,
+        }
+    }
+}
+
+impl From<gl::types::GLenum> for FrontFace {
+    fn from(front_face: gl::types::GLenum) -> Self {
+        match front_face {
+            gl::CCW => FrontFace::Ccw,
+            gl::CW => FrontFace::Cw,
+            _ => panic!("Unknown front face found: {}", front_face),
         }
     }
 }


### PR DESCRIPTION
This adds a `FrontFace` enum to render primitives (triangles) in clock wise (CW) or counter clock wise order (CCW). The front face defines the "side" of a triangle to be rendered or not. In most cases solid 3D objects have an inner & outer side, therefore when rendering these objects the visible outer side is rendered, while everything behind it that is invisible in the viewport does not need to be rendered or would be drawn over by objects in front of it e.g. not all sides of a cube are visible and need to be rendered.