### PR TITLE
Refactor Framebuffer functions

### DIFF
--- a/src/render/render_buffer.rs
+++ b/src/render/render_buffer.rs
@@ -99,5 +99,6 @@ impl Drop for RenderBuffer {
         unsafe {
             gl::DeleteRenderbuffers(1, &self.id);
         }
+        self.id = 0;
     }
 }


### PR DESCRIPTION
This PR refactors a few aspects of `Framebuffer` and `RenderBuffer`.

* allocate GPU memory when initialising `RenderBuffer` instance, providing width and height
* add enum value `Back` as attachment to reference default swappable framebuffer
* add `clear` function to framebuffer