### PR TITLE
Set texture with unit index in Program

### DIFF
--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -431,7 +431,10 @@ impl Program {
     /// * `unit` - The unit slot to attach the texture
     /// * `texture` - The texture reference to use
     pub fn sampler(&mut self, name: &str, unit: u32, texture: &mut Texture) -> &mut Self {
-        texture.bind();
+        unsafe {
+            gl::ActiveTexture(gl::TEXTURE0 + unit);
+            gl::BindTexture(texture.target, texture.id);
+        }
         self.uniform(name, Uniform::Integer(unit as i32));
         self
     }


### PR DESCRIPTION
Before the change only the first texture slot could be set as uniform variable in the shader.