### PR TITLE
Add ops functions to Vector2

### DIFF
--- a/examples/05-worley-noise/main.rs
+++ b/examples/05-worley-noise/main.rs
@@ -63,7 +63,12 @@ fn main() {
         program.uniform("u_resolution", size.into());
         program.uniform("u_depth", depth.into());
         program.uniform("u_time", elapsed.into());
-        program.uniform("u_featurePoints[0]", Uniform::Vec3Array(points.clone()));
+        // program.uniform("u_featurePoints[0]", Uniform::Vec3Array(points.clone()));
+        let verts = points
+            .iter()
+            .map(|v| [v.x, v.y, v.z])
+            .collect::<Vec<[f32; 3]>>();
+        program.uniform("u_featurePoints[0]", Uniform::Vec3Array(verts));
 
         vao.bind();
         vao.draw();

--- a/src/math/vector2.rs
+++ b/src/math/vector2.rs
@@ -1,4 +1,4 @@
-use std::ops::Sub;
+use std::ops::{Add, Sub, AddAssign, MulAssign, Mul};
 
 pub type Point2 = Vector2;
 
@@ -8,10 +8,28 @@ pub struct Vector2 {
     pub y: f32,
 }
 
+/// Rotates the given vector by angle, returns the rotated Vector2
+fn rotate(v: &Vector2, angle: cgmath::Rad<f32>) -> Vector2 {
+    let c = angle.0.cos();
+    let s = angle.0.sin();
+    let x = v.x * c - v.y * s;
+    let y = v.x * s + v.y * c;
+    Vector2 {
+        x, y
+    }
+}
+
 impl Vector2 {
     /// Construct a new vector
     pub fn new(x: f32, y: f32) -> Self {
         Self { x, y }
+    }
+
+    /// Normalizes the vector to unit length
+    pub fn normalize(&mut self) {
+        let l = self.length();
+        self.x /= l;
+        self.y /= l;
     }
 
     /// Calculate distance to another Vector
@@ -22,6 +40,51 @@ impl Vector2 {
     /// Calculates the length of the Vector
     pub fn length(&self) -> f32 {
         (self.x * self.x + self.y * self.y).sqrt()
+    }
+}
+
+impl Mul<cgmath::Rad<f32>> for Vector2 {
+    type Output = Vector2;
+
+    fn mul(self, rhs: cgmath::Rad<f32>) -> Self::Output {
+        rotate(&self, rhs)
+    }
+}
+
+impl Mul<cgmath::Deg<f32>> for Vector2 {
+    type Output = Vector2;
+
+    fn mul(self, rhs: cgmath::Deg<f32>) -> Self::Output {
+        rotate(&self, rhs.into())
+    }
+}
+
+impl Add for Vector2 {
+    type Output = Vector2;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Vector2 {
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+        }
+    }
+}
+
+impl AddAssign for Vector2 {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = Self {
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+        }
+    }
+}
+
+impl MulAssign<f32> for Vector2 {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = Self {
+            x: self.x * rhs,
+            y: self.y * rhs,
+        }
     }
 }
 

--- a/src/render/program.rs
+++ b/src/render/program.rs
@@ -109,9 +109,9 @@ pub enum Uniform {
     Mat3(Matrix3<f32>),
     Mat4(Matrix4<f32>),
     Vec2(Vector2<f32>),
-    Vec2Array(Vec<Vector2<f32>>),
+    Vec2Array(Vec<[f32; 2]>),
     Vec3(Vector3<f32>),
-    Vec3Array(Vec<Vector3<f32>>),
+    Vec3Array(Vec<[f32; 3]>),
     Point3(Point3<f32>),
     Size(f32, f32),
 }
@@ -152,8 +152,8 @@ impl From<Vector2<f32>> for Uniform {
     }
 }
 
-impl From<Vec<Vector2<f32>>> for Uniform {
-    fn from(vertices: Vec<Vector2<f32>>) -> Self {
+impl From<Vec<[f32; 2]>> for Uniform {
+    fn from(vertices: Vec<[f32; 2]>) -> Self {
         Uniform::Vec2Array(vertices)
     }
 }
@@ -164,8 +164,8 @@ impl From<Vector3<f32>> for Uniform {
     }
 }
 
-impl From<Vec<Vector3<f32>>> for Uniform {
-    fn from(vertices: Vec<Vector3<f32>>) -> Self {
+impl From<Vec<[f32; 3]>> for Uniform {
+    fn from(vertices: Vec<[f32; 3]>) -> Self {
         Uniform::Vec3Array(vertices)
     }
 }
@@ -469,7 +469,7 @@ impl Program {
         }
     }
 
-    pub fn uniform2fv(location: i32, vertices: &Vec<Vector2<f32>>) {
+    pub fn uniform2fv(location: i32, vertices: &Vec<[f32; 2]>) {
         unsafe {
             gl::Uniform2fv(location, vertices.len() as i32, vertices.as_ptr() as *const _);
         }
@@ -481,7 +481,7 @@ impl Program {
         }
     }
 
-    pub fn uniform3fv(location: i32, vertices: &Vec<Vector3<f32>>) {
+    pub fn uniform3fv(location: i32, vertices: &Vec<[f32; 3]>) {
         unsafe {
             gl::Uniform3fv(location, vertices.len() as i32, vertices.as_ptr() as *const _);
         }


### PR DESCRIPTION
This PR adds a few arithmetic function to Vector2 struct.

* refactor Uniform enum values to use `Vec<[f32; x]>` instead of `Vec<Vec<f32>>` , it's more generic and efficient.