### PR TITLE
Add cube / mesh structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ debug-assertions = true
 
 [[example]]
 name = "spinningcube"
-path = "examples/01-spinning-cube/main.rs"
+path = "examples/01-spinning-cube-wgpu/main.rs"
 
 [[example]]
 name = "triangles"

--- a/examples/01-spinning-cube-wgpu/main.rs
+++ b/examples/01-spinning-cube-wgpu/main.rs
@@ -1,17 +1,32 @@
-use renderer::{Renderer, ShaderLayout, ShaderStage, VertexBufferDescriptor, VertexFormat, VertexStateDescriptor};
+use std::collections::HashMap;
+
+use renderer::{Renderer, Shader, ShaderStage, WindowHandler, WindowSettings};
+
+pub struct Example {
+    shaders: HashMap<ShaderStage, Shader>,
+}
+
+impl WindowHandler for Example {
+    fn load(_window: &renderer::Window, _resources: &resources::Resources, renderer: &mut Renderer) -> Self where Self: Sized {
+        let vertex_shader = renderer.create_shader(include_str!("shaders/vertex.glsl"), ShaderStage::Vertex);
+        let fragment_shader = renderer.create_shader(include_str!("shaders/fragment.glsl"), ShaderStage::Fragment);
+
+        let mut shaders = HashMap::new();
+        shaders.insert(ShaderStage::Vertex, vertex_shader);
+        shaders.insert(ShaderStage::Fragment, fragment_shader);
+
+        Example {
+            shaders,
+        }
+    }
+
+    fn render(&mut self, window: &mut renderer::Window, renderer: &mut Renderer) {
+        let mut render_pass = renderer.begin_render_pass();
+        render_pass.begin(&mut window.surface, &window.depth_buffer, &self.shaders);
+        render_pass.finish();
+    }
+}
 
 fn main() {
-    let vertex_source = include_str!("shaders/vertex.glsl");
-    let fragment_source = include_str!("shaders/fragment.glsl");
-
-    let renderer = futures::executor::block_on(Renderer::new());
-    let _vertex_shader = renderer.create_shader(vertex_source, ShaderStage::Vertex);
-    let fragment_shader = renderer.create_shader(fragment_source,  ShaderStage::Fragment);
-
-    // check what is parsed
-    let shader_layout = ShaderLayout::from_shader(&fragment_shader);
-    dbg!(shader_layout);
-
-    let mut vertex_stage = VertexStateDescriptor::new();
-    vertex_stage.add(VertexBufferDescriptor::new(vec![VertexFormat::Float3]));
+    Example::run(WindowSettings::default());
 }

--- a/examples/01-spinning-cube/shaders/vertex.glsl
+++ b/examples/01-spinning-cube/shaders/vertex.glsl
@@ -7,8 +7,8 @@ uniform mat3 u_normalMatrix;
 layout(location = 0) in vec3 i_position;
 layout(location = 1) in vec3 i_normal;
 
-layout (location = 0) out vec3 vertex;
-layout (location = 1) out vec3 normal;
+layout(location = 0) out vec3 vertex;
+layout(location = 1) out vec3 normal;
 
 void main() {
     gl_Position = u_modelViewProjection * vec4(i_position, 1.0);

--- a/src/renderer/src/lib.rs
+++ b/src/renderer/src/lib.rs
@@ -3,6 +3,7 @@ extern crate shaderc;
 
 mod buffer;
 mod converter;
+mod mesh;
 mod pipeline;
 mod render;
 mod renderer;
@@ -14,10 +15,10 @@ mod window;
 
 pub use buffer::*;
 pub use converter::*;
+pub use mesh::*;
 pub use pipeline::*;
 pub use render::*;
 pub use renderer::*;
-use resources::Resources;
 pub use shader::*;
 pub use surface::*;
 pub use texture::*;

--- a/src/renderer/src/mesh/mesh.rs
+++ b/src/renderer/src/mesh/mesh.rs
@@ -1,0 +1,234 @@
+use std::borrow::Cow;
+
+use crate::PrimitiveTopology;
+
+#[derive(Debug)]
+pub enum VertexAttributeValues {
+    Float(Vec<f32>),
+    Float2(Vec<[f32; 2]>),
+    Float3(Vec<[f32; 3]>),
+    Float4(Vec<[f32; 4]>),
+}
+
+impl VertexAttributeValues {
+    pub fn len(&self) -> usize {
+        match *self {
+            VertexAttributeValues::Float(ref values) => values.len(),
+            VertexAttributeValues::Float2(ref values) => values.len(),
+            VertexAttributeValues::Float3(ref values) => values.len(),
+            VertexAttributeValues::Float4(ref values) => values.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[derive(Debug)]
+pub struct VertexAttribute {
+    /// The name of the vertex attribute
+    pub name: Cow<'static, str>,
+    /// The list of vertex attribute values
+    pub values: VertexAttributeValues,
+}
+
+impl VertexAttribute {
+    /// Sets the positions for the mesh
+    pub fn positions(positions: Vec<[f32; 3]>) -> Self {
+        VertexAttribute {
+            name: "positions".into(),
+            values: VertexAttributeValues::Float3(positions),
+        }
+    }
+
+    /// Sets the normals for the mesh
+    pub fn normals(normals: Vec<[f32; 3]>) -> Self {
+        VertexAttribute {
+            name: "normals".into(),
+            values: VertexAttributeValues::Float3(normals),
+        }
+    }
+
+    /// Sets the tex coords / uv coords for all vertices
+    pub fn texcoords(texcoords: Vec<[f32; 2]>) -> Self {
+        VertexAttribute {
+            name: "texcoords".into(),
+            values: VertexAttributeValues::Float2(texcoords),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Indices {
+    /// u16 based indices list
+    U16(Vec<u16>),
+    /// u32 based indices list
+    U32(Vec<u32>),
+}
+
+/// A Mesh struct that contains vertices, normals, tex coords.
+#[derive(Debug)]
+pub struct Mesh {
+    /// Type of primitive topology
+    pub topology: PrimitiveTopology,
+    /// The list of vertex attributes
+    pub attributes: Vec<VertexAttribute>,
+    /// The list of optional indices referencing vertex data
+    pub indices: Option<Indices>,
+}
+
+impl Mesh {
+    /// Creates a new Mesh instance
+    pub fn new(topology: PrimitiveTopology) -> Self {
+        Mesh {
+            topology,
+            attributes: Vec::new(),
+            indices: None,
+        }
+    }
+}
+
+pub mod shape {
+    use crate::{Indices, Mesh, PrimitiveTopology, VertexAttribute};
+
+    pub struct Cube {
+        /// Half the side length of the cube
+        pub size: f32,
+    }
+
+    impl Default for Cube {
+        fn default() -> Self {
+            Cube { size: 1.0, }
+        }
+    }
+
+    impl From<Cube> for Mesh {
+        fn from(cube: Cube) -> Self {
+            let half = cube.size / 2.0;
+            let vertices = vec![
+                [-half, -half,  half],
+                [ half, -half,  half],
+                [ half,  half,  half],
+                [-half,  half,  half],
+
+                [-half, -half, -half],
+                [-half,  half, -half],
+                [ half,  half, -half],
+                [ half, -half, -half],
+
+                [-half,  half, -half],
+                [-half,  half,  half],
+                [ half,  half,  half],
+                [ half,  half, -half],
+
+                [-half, -half, -half],
+                [ half, -half, -half],
+                [ half, -half,  half],
+                [-half, -half,  half],
+
+                [ half, -half, -half],
+                [ half,  half, -half],
+                [ half,  half,  half],
+                [ half, -half,  half],
+
+                [-half, -half, -half],
+                [-half, -half,  half],
+                [-half,  half,  half],
+                [-half,  half, -half],
+            ];
+
+            let normals = vec![
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0],
+
+                [0.0, 0.0, -1.0],
+                [0.0, 0.0, -1.0],
+                [0.0, 0.0, -1.0],
+                [0.0, 0.0, -1.0],
+
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+
+                [0.0, -1.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, -1.0, 0.0],
+
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+
+                [-1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+            ];
+
+            let texcoords = vec![
+                [0.0,  0.0],
+                [1.0,  0.0],
+                [1.0,  1.0],
+                [0.0,  1.0],
+
+                [0.0,  0.0],
+                [1.0,  0.0],
+                [1.0,  1.0],
+                [0.0,  1.0],
+
+                [0.0,  0.0],
+                [1.0,  0.0],
+                [1.0,  1.0],
+                [0.0,  1.0],
+
+                [0.0,  0.0],
+                [1.0,  0.0],
+                [1.0,  1.0],
+                [0.0,  1.0],
+
+                [0.0,  0.0],
+                [1.0,  0.0],
+                [1.0,  1.0],
+                [0.0,  1.0],
+
+                [0.0,  0.0],
+                [1.0,  0.0],
+                [1.0,  1.0],
+                [0.0,  1.0],
+            ];
+
+            let indices = Indices::U32(vec![
+                0,  1,  2,    0,  2,  3,  // Front face
+                4,  5,  6,    4,  6,  7,  // Back face
+                8,  9, 10,    8, 10, 11,  // Top face
+               12, 13, 14,   12, 14, 15,  // Bottom face
+               16, 17, 18,   16, 18, 19,  // Right face
+               20, 21, 22,   20, 22, 23   // Left face
+            ]);
+
+            Mesh {
+                topology: PrimitiveTopology::TriangleList,
+                attributes: vec![
+                    VertexAttribute::positions(vertices),
+                    VertexAttribute::normals(normals),
+                    VertexAttribute::texcoords(texcoords),
+                ],
+                indices: Some(indices),
+            }
+        }
+    }
+}
+
+/*
+    /// Type of primitive topology
+    pub topology: PrimitiveTopology,
+    /// The list of vertex attributes
+    pub attributes: Vec<VertexAttribute>,
+    /// The list of optional indices referencing vertex data
+    pub indices: Option<Indices>,
+*/

--- a/src/renderer/src/mesh/mod.rs
+++ b/src/renderer/src/mesh/mod.rs
@@ -1,0 +1,3 @@
+pub mod mesh;
+
+pub use mesh::*;

--- a/src/renderer/src/render/render_pass.rs
+++ b/src/renderer/src/render/render_pass.rs
@@ -108,6 +108,11 @@ impl<'a> RenderPass {
         render_pass.set_pipeline(&render_pipeline);
     }
 
+    /// TODO Sets a vertex buffer
+    pub fn set_vertex_buffer(&mut self) -> &mut Self {
+        self
+    }
+
     /// Finishes the Render Pass
     pub fn finish(&mut self) {
         assert!(self.encoder.is_some());

--- a/src/renderer/src/window/window_handler.rs
+++ b/src/renderer/src/window/window_handler.rs
@@ -16,7 +16,7 @@ pub trait WindowHandler {
     fn resize(&mut self, _width: u32, _height: u32) {}
 
     /// Method to update all entities in the window.
-    fn update(&mut self, _resources: &Resources);
+    fn update(&mut self, _resources: &Resources) {}
 
     /// Renders data to the frame buffer
     fn render(&mut self, _window: &mut Window, app: &mut Renderer);


### PR DESCRIPTION
Start to adapt spinning cube example to use wgpu related structs.

* refactor wgpu example to use spirv shaders
* add mesh struct including a cube mesh that consists vertex data