### PR TITLE
Extend example, add camera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,6 +1754,7 @@ dependencies = [
  "bevy_ecs 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytemuck 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgmath 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "resources 0.1.0",
  "shaderc 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/examples/01-spinning-cube-wgpu/main.rs
+++ b/examples/01-spinning-cube-wgpu/main.rs
@@ -1,13 +1,19 @@
 use std::collections::HashMap;
 
-use renderer::{Renderer, Shader, ShaderStage, WindowHandler, WindowSettings};
+use cgmath::vec3;
+use renderer::{Camera, Mesh, Renderer, Shader, ShaderStage, WindowHandler, WindowSettings, point3, shape};
 
 pub struct Example {
+    /// The shaders to render
     shaders: HashMap<ShaderStage, Shader>,
+    /// The cube mesh to render
+    mesh: Mesh,
+    /// The camera to view the scene from
+    camera: Camera,
 }
 
 impl WindowHandler for Example {
-    fn load(_window: &renderer::Window, _resources: &resources::Resources, renderer: &mut Renderer) -> Self where Self: Sized {
+    fn load(window: &renderer::Window, _resources: &resources::Resources, renderer: &mut Renderer) -> Self where Self: Sized {
         let vertex_shader = renderer.create_shader(include_str!("shaders/vertex.glsl"), ShaderStage::Vertex);
         let fragment_shader = renderer.create_shader(include_str!("shaders/fragment.glsl"), ShaderStage::Fragment);
 
@@ -15,8 +21,22 @@ impl WindowHandler for Example {
         shaders.insert(ShaderStage::Vertex, vertex_shader);
         shaders.insert(ShaderStage::Fragment, fragment_shader);
 
+        let mesh = shape::Cube::new(1.0).into();
+        let mut camera = Camera::default();
+        camera
+            .perspective(window.aspect())
+            .look_at(
+                point3(0.0, 1.0, -2.5),
+                point3(0.0, 0.0, 0.0),
+                vec3(0.0, 1.0, 0.0),
+            );
+
+        let buffer = renderer.create_buffer(data);
+
         Example {
             shaders,
+            mesh,
+            camera,
         }
     }
 

--- a/src/renderer/Cargo.toml
+++ b/src/renderer/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Sebastian Ziebell"]
 bevy_ecs = "0.2.1"
 bitflags = "1.2.1"
 bytemuck = "1.4.1"
+cgmath = "0.17.0"
 futures = "0.3.5"
 resources = { path = "../resources", version = "0.1.0" }
 shaderc = { version = "0.6.2" }

--- a/src/renderer/src/camera/camera.rs
+++ b/src/renderer/src/camera/camera.rs
@@ -1,0 +1,104 @@
+use cgmath::{EuclideanSpace, Matrix4, One, Point3, Quaternion, SquareMatrix, Vector3};
+
+pub fn convert_to_quaternion(mat: &Matrix4<f32>) -> Quaternion<f32> {
+    let trace = mat.x.x + mat.y.y + mat.z.z;
+
+    let s;
+    let x: f32;
+    let y: f32;
+    let z: f32;
+    let w: f32;
+
+    if trace > 0.0 {
+        s = (trace + 1.0).sqrt() * 2.0;
+        w = 0.25 * s;
+        x = (mat.z.y - mat.y.z) / s;
+        y = (mat.x.z - mat.z.x) / s;
+        z = (mat.y.x - mat.x.y) / s;
+    } else if (mat.x.x > mat.y.y) & (mat.x.x > mat.z.z) {
+        s = (1.0 + mat.x.x - mat.y.y - mat.z.z).sqrt() * 2.0;
+        w = (mat.z.y - mat.y.z) / s;
+        x = 0.25 * s;
+        y = (mat.x.y + mat.y.x) / s;
+        z = (mat.x.z + mat.z.x) / s;
+    } else if mat.y.y > mat.z.z {
+        s = (1.0 + mat.y.y - mat.x.x - mat.z.z).sqrt() * 2.0;
+        w = (mat.x.z - mat.z.x) / s;
+        x = (mat.x.y + mat.y.x) / s;
+        y = 0.25 * s;
+        z = (mat.y.z + mat.z.y) / s;
+    } else {
+        s = (1.0 + mat.z.z - mat.x.x - mat.y.y) * 2.0;
+        w = (mat.y.x - mat.x.y) / s;
+        x = (mat.x.z + mat.z.x) / s;
+        y = (mat.y.z + mat.z.y) / s;
+        z = 0.25 * s;
+    }
+
+    Quaternion::new(w, x, y, z)
+}
+
+#[derive(Debug)]
+pub struct Camera {
+    pub znear: f32,
+    pub zfar: f32,
+    pub aspect: f32,
+    pub fov: f32,
+
+    pub projection: Matrix4<f32>,
+    pub view: Matrix4<f32>,
+    pub position: Point3<f32>,
+    pub orientation: Quaternion<f32>,
+}
+
+impl Default for Camera {
+    fn default() -> Self {
+        Self {
+            znear: 0.1,
+            zfar: 100.0,
+            fov: 60.0,
+            aspect: 1.0,
+            projection: Matrix4::one(),
+            view: Matrix4::one(),
+            position: Point3::new(0.0, 0.0, 0.0),
+            orientation: Quaternion::one(),
+        }
+    }
+}
+
+impl Camera {
+    /// Sets the perspective from given aspect ratio
+    pub fn perspective(&mut self, aspect: f32) -> &mut Self {
+        self.aspect = aspect;
+        self
+    }
+
+    /// Sets field of view
+    pub fn fov(&mut self, fov: f32) -> &mut Self {
+        self.fov = fov;
+        self
+    }
+
+    /// Sets the z near & far values
+    pub fn depth(&mut self, znear: f32, zfar: f32) -> &mut Self {
+        self.znear = znear;
+        self.zfar = zfar;
+        self
+    }
+
+    /// Sets the look at matrix from eye, center and up vector
+    pub fn look_at(&mut self, eye: Point3<f32>, center: Point3<f32>, up: Vector3<f32>) -> &mut Self {
+        self.position = eye;
+        self.view = Matrix4::look_at(eye, center, up);
+        self.orientation = convert_to_quaternion(&self.view);
+        self.update_view();
+        self
+    }
+
+    fn update_view(&mut self) -> &mut Self {
+        let rotation = Matrix4::from(self.orientation);
+        let translation = Matrix4::from_translation(self.position.to_vec());
+        self.view = rotation * translation.invert().unwrap();
+        self
+    }
+}

--- a/src/renderer/src/camera/mod.rs
+++ b/src/renderer/src/camera/mod.rs
@@ -1,0 +1,3 @@
+pub mod camera;
+
+pub use camera::Camera;

--- a/src/renderer/src/lib.rs
+++ b/src/renderer/src/lib.rs
@@ -2,6 +2,7 @@ extern crate bitflags;
 extern crate shaderc;
 
 mod buffer;
+mod camera;
 mod converter;
 mod mesh;
 mod pipeline;
@@ -14,6 +15,8 @@ mod vertex;
 mod window;
 
 pub use buffer::*;
+pub use camera::*;
+use cgmath::Point3;
 pub use converter::*;
 pub use mesh::*;
 pub use pipeline::*;
@@ -24,3 +27,7 @@ pub use surface::*;
 pub use texture::*;
 pub use vertex::*;
 pub use window::*;
+
+pub fn point3(x: f32, y: f32, z: f32) -> Point3<f32> {
+    Point3 { x, y, z }
+}

--- a/src/renderer/src/mesh/mesh.rs
+++ b/src/renderer/src/mesh/mesh.rs
@@ -97,6 +97,12 @@ pub mod shape {
         pub size: f32,
     }
 
+    impl Cube {
+        pub fn new(size: f32) -> Self {
+            Cube { size }
+        }
+    }
+
     impl Default for Cube {
         fn default() -> Self {
             Cube { size: 1.0, }

--- a/src/renderer/src/surface.rs
+++ b/src/renderer/src/surface.rs
@@ -46,6 +46,11 @@ impl Surface {
         &self.output.as_ref().unwrap().output.view
     }
 
+    /// Returns the aspect ratio of the underlying window
+    pub fn aspect(&self) -> f32 {
+        (self.width() as f32) / (self.height() as f32)
+    }
+
     /// Returns width of the surface
     pub fn width(&self) -> u32 {
         self.window.inner_size().width

--- a/src/renderer/src/window/window.rs
+++ b/src/renderer/src/window/window.rs
@@ -36,6 +36,11 @@ impl Window {
         }
     }
 
+    /// Returns the aspect ratio
+    pub fn aspect(&self) -> f32 {
+        self.surface.aspect()
+    }
+
     /// Returns width of the window
     pub fn width(&self) -> u32 {
         self.surface.width()


### PR DESCRIPTION
This adds a `Camera` struct to the spinning cube example.

* add function to calculate aspect ratio of Window